### PR TITLE
chore: add service field in labels for conn type logs

### DIFF
--- a/corelight.conf
+++ b/corelight.conf
@@ -7049,6 +7049,27 @@ filter {
     }
 
     mutate {
+      replace => {
+        "suricata_service.value" => "%{service}"
+      }
+      on_error => "suricata_service_not_set"
+    }
+
+    if ![suricata_service_not_set] and [suricata_service][value] != "" {
+      mutate {
+        replace => {
+          "suricata_service.key" => "service"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_about.labels" => "suricata_service"
+        }
+      }
+    }
+
+    mutate {
       rename => {
         "token_about" => "suricata_about"
       }

--- a/corelight.conf
+++ b/corelight.conf
@@ -4751,10 +4751,10 @@ filter {
       replace => {
         "token_service.value" => "%{service}"
       }
-      on_error => "tocken_service_not_set"
+      on_error => "token_service_not_set"
     }
 
-    if ![tocken_service_not_set] and [token_service][value] != "" {
+    if ![token_service_not_set] and [token_service][value] != "" {
       mutate {
         replace => {
           "token_service.key" => "service"

--- a/corelight.conf
+++ b/corelight.conf
@@ -4749,6 +4749,27 @@ filter {
 
     mutate {
       replace => {
+        "token_service.value" => "%{service}"
+      }
+      on_error => "tocken_service_not_set"
+    }
+
+    if ![tocken_service_not_set] and [token_service][value] != "" {
+      mutate {
+        replace => {
+          "token_service.key" => "service"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_about.labels" => "token_service"
+        }
+      }
+    }
+
+    mutate {
+      replace => {
         "service" => "%{service}"
       }
       on_error => "service_not_set"

--- a/corelight_md.md
+++ b/corelight_md.md
@@ -450,6 +450,11 @@ The following table lists the log fields of the <code>conn, conn_red, conn_long<
 <td><code>security_result.severity</code></td>
 <td>The <code>security_result.severity</code> UDM field is set to <code>INFORMATIONAL</code>.</td>
 </tr>
+<tr>
+<td><code>service (string)</code></td>
+<td><code>about.labels [service]</code></td>
+<td></td>
+</tr>
 </tbody>
 </table>
 </devsite-filter>

--- a/corelight_md.md
+++ b/corelight_md.md
@@ -2632,6 +2632,11 @@ The following table lists the log fields of the <code>suricata_corelight</code> 
 <td><code>target.asset.vulnerabilities.cve_description</code></td>
 <td></td>
 </tr>
+<tr>
+<td><code>service (string)</code></td>
+<td><code>about.labels [service]</code></td>
+<td></td>
+</tr>
 </tbody>
 </table>
 </devsite-filter>


### PR DESCRIPTION
The service field is also mapped with about.labels [service] for conn log type.