### PR TITLE
adding corelight.conf: contains mapping of v27.12 logschema

### DIFF
--- a/corelight.conf
+++ b/corelight.conf
@@ -2,7 +2,7 @@
 # Category: NDR
 # Supported Format: JSON
 # Reference: See below
-# Last Updated: 2023-04-28
+# Last Updated: 2024-09-20
 # Copyright 2023 Chronicle LLC
 
 filter {
@@ -13,7 +13,7 @@ filter {
     }
   }
 
-  # remove syslog header
+  # Remove syslog header
   # - if using JSON over Syslog
   grok {
     match => {
@@ -37,7 +37,8 @@ filter {
     gsub => ["message", '"mgmt.out.packets.kpps"', '"mgmt.out.packets_kpps"']
   }
   mutate {
-    gsub => ["message", '"monitor.total.drops.kpps"', '"monitor.total.drops_kpps"']
+    gsub => ["message", '"monitor.total.drops.kpps"',
+    '"monitor.total.drops_kpps"']
   }
   mutate {
     gsub => ["message", '"cpu"', '"bro_cpu"']
@@ -52,6 +53,7 @@ filter {
 
   if [not_json] or [_path] == "" {
     drop {
+      "tag" => "TAG_MALFORMED_ENCODING"
     }
   }
 
@@ -89,6 +91,12 @@ filter {
     on_error => "ts_not_found"
   }
 
+  date {
+    match => ["_write_ts", "RFC3339"]
+    target => "token_metadata.collected_timestamp"
+    on_error => "write_ts_not_found"
+  }
+
   mutate {
     replace => {
       "uid_present" => "%{uid}"
@@ -114,6 +122,294 @@ filter {
       "token_metadata.product_event_type" => "%{_path}"
     }
     on_error => "_path_not_found"
+  }
+
+  if [_path] not in ["intel","known_certs","known_devices","known_domains",
+  "known_hosts","known_names","known_remotes",
+  "known_services","known_users"] {
+    mutate {
+      convert => {
+        "id.vlan" => "string"
+      }
+      on_error => "id_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_vlan_label.value.string_value" => "%{id.vlan}"
+      }
+      on_error => "id_vlan_not_found"
+    }
+
+    if ![id_vlan_not_found] and
+      [id_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_vlan_label.key" => "id_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.vlan_inner" => "string"
+      }
+      on_error => "id_vlan_inner_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_vlan_inner_label.value.string_value" => "%{id.vlan_inner}"
+      }
+      on_error => "id_vlan_inner_not_found"
+    }
+
+    if ![id_vlan_inner_not_found] and
+      [id_vlan_inner_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_vlan_inner_label.key" => "id_vlan_inner"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_vlan_inner_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_cid" => "string"
+      }
+      on_error => "id_orig_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_cid_label.value.string_value" => "%{id.orig_ep_cid}"
+      }
+      on_error => "id_orig_ep_cid_not_found"
+    }
+
+    if ![id_orig_ep_cid_not_found] and
+      [id_orig_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_cid_label.key" => "id_orig_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_source" => "string"
+      }
+      on_error => "id_orig_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_source_label.value.string_value" =>
+        "%{id.orig_ep_source}"
+      }
+      on_error => "id_orig_ep_source_not_found"
+    }
+
+    if ![id_orig_ep_source_not_found] and
+      [id_orig_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_source_label.key" => "id_orig_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_status" => "string"
+      }
+      on_error => "id_orig_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_status_label.value.string_value" =>
+        "%{id.orig_ep_status}"
+      }
+      on_error => "id_orig_ep_status_not_found"
+    }
+
+    if ![id_orig_ep_status_not_found] and
+      [id_orig_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_status_label.key" => "id_orig_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_uid" => "string"
+      }
+      on_error => "id_orig_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_uid_label.value.string_value" => "%{id.orig_ep_uid}"
+      }
+      on_error => "id_orig_ep_uid_not_found"
+    }
+
+    if ![id_orig_ep_uid_not_found] and
+      [id_orig_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_uid_label.key" => "id_orig_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_uid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_cid" => "string"
+      }
+      on_error => "id_resp_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_cid_label.value.string_value" => "%{id.resp_ep_cid}"
+      }
+      on_error => "id_resp_ep_cid_not_found"
+    }
+
+    if ![id_resp_ep_cid_not_found] and
+      [id_resp_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_cid_label.key" => "id_resp_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_source" => "string"
+      }
+      on_error => "id_resp_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_source_label.value.string_value" =>
+        "%{id.resp_ep_source}"
+      }
+      on_error => "id_resp_ep_source_not_found"
+    }
+
+    if ![id_resp_ep_source_not_found] and
+      [id_resp_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_source_label.key" => "id_resp_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_status" => "string"
+      }
+      on_error => "id_resp_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_status_label.value.string_value" =>
+        "%{id.resp_ep_status}"
+      }
+      on_error => "id_resp_ep_status_not_found"
+    }
+
+    if ![id_resp_ep_status_not_found] and
+      [id_resp_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_status_label.key" => "id_resp_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_uid" => "string"
+      }
+      on_error => "id_resp_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_uid_label.value.string_value" => "%{id.resp_ep_uid}"
+      }
+      on_error => "id_resp_ep_uid_not_found"
+    }
+
+    if ![id_resp_ep_uid_not_found] and
+      [id_resp_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_uid_label.key" => "id_resp_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_uid_label"
+        }
+      }
+    }
   }
 
   # UDM > Observer > Hostname
@@ -271,9 +567,9 @@ filter {
       convert => {
         "response_body_len" => "uinteger"
       }
-      on_error => "conversion_error"
+      on_error => "response_body_len_conversion_error"
     }
-    if ![conversion_error] {
+    if ![response_body_len_conversion_error] {
       mutate {
         rename => {
           "response_body_len" => "token_network.received_bytes"
@@ -286,9 +582,9 @@ filter {
       convert => {
         "request_body_len" => "uinteger"
       }
-      on_error => "conversion_error"
+      on_error => "request_body_len_conversion_error"
     }
-    if ![conversion_error] {
+    if ![request_body_len_conversion_error] {
       mutate {
         rename => {
           "request_body_len" => "token_network.sent_bytes"
@@ -297,12 +593,20 @@ filter {
       }
     }
 
-    #UDM > Principal
+    # UDM > Principal
     mutate {
       replace => {
-        "token_principal.hostname" => "%{origin}"
+        "_" => "%{origin}"
       }
       on_error => "origin_not_found"
+    }
+
+    if ![origin_not_found] and [origin] =~ "^(.){1,253}$" {
+      mutate {
+        replace => {
+          "token_principal.hostname" => "%{origin}"
+        }
+      }
     }
 
     mutate {
@@ -376,9 +680,17 @@ filter {
     # UDM > Target
     mutate {
       replace => {
-        "token_target.hostname" => "%{host}"
+        "_" => "%{host}"
       }
       on_error => "host_not_found"
+    }
+
+    if ![host_not_found] and [host] =~ "^(.){1,253}$" {
+      mutate {
+        replace => {
+          "token_target.hostname" => "%{host}"
+        }
+      }
     }
 
     mutate {
@@ -456,20 +768,30 @@ filter {
           "proxy_intermediary" => ""
         }
       }
+
       mutate {
         replace => {
-          "proxy_intermediary.hostname" => "%{proxy}"
+          "_" => "%{proxy}"
         }
-      }
-      mutate {
-        merge => {
-          "token_intermediary" => "proxy_intermediary"
-        }
+        on_error => "proxy_not_found"
       }
 
+      if ![proxy_not_found] and [proxy] =~ "^(.){1,253}$" {
+        mutate {
+          replace => {
+            "proxy_intermediary.hostname" => "%{proxy}"
+          }
+        }
+        mutate {
+          merge => {
+            "token_intermediary" => "proxy_intermediary"
+          }
+          on_error => "proxy_intermediary_not_found"
+        }
+      }
     }
 
-    #UDM > Extensions
+    # UDM > Extensions
 
     mutate {
       replace => {
@@ -478,7 +800,7 @@ filter {
       on_error => "password_not_found"
     }
 
-    #UDM > About
+    # UDM > About
 
     mutate {
       merge => {
@@ -653,7 +975,7 @@ filter {
       convert => {
         "stream_id" => "string"
       }
-      on_error => "conversion_error"
+      on_error => "stream_id_conversion_error"
     }
     mutate {
       replace => {
@@ -752,7 +1074,7 @@ filter {
       on_error => "token_about_not_set"
     }
 
-    # check if required udm validation fields for NETWORK_HTTP exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_HTTP exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -775,7 +1097,7 @@ filter {
   # CORELIGHT_METRICS_BRO
 
   else if [_path] == "corelight_metrics_bro" {
-    
+
     # conn
     mutate {
       convert => {
@@ -1081,7 +1403,8 @@ filter {
       on_error => "logs_kerberos_not_set"
     }
 
-    if ![logs_kerberos_not_set] and [logs][kerberos][entries][per-second] != "" {
+    if ![logs_kerberos_not_set]
+    and [logs][kerberos][entries][per-second] != "" {
       mutate {
         replace => {
           "token_logs_kerberos.key" => "logs_kerberos_entries_per_second"
@@ -1342,7 +1665,8 @@ filter {
       on_error => "logs_smb_files_not_set"
     }
 
-    if ![logs_smb_files_not_set] and [logs][smb_files][entries][per-second] != "" {
+    if ![logs_smb_files_not_set]
+    and [logs][smb_files][entries][per-second] != "" {
       mutate {
         replace => {
           "token_logs_smb_files.key" => "logs_smb_files_entries_per_second"
@@ -1366,12 +1690,14 @@ filter {
 
     mutate {
       replace => {
-        "token_logs_smb_mapping.value" => "%{logs.smb_mapping.entries.per-second}"
+        "token_logs_smb_mapping.value" =>
+        "%{logs.smb_mapping.entries.per-second}"
       }
       on_error => "logs_smb_mapping_not_set"
     }
 
-    if ![logs_smb_mapping_not_set] and [logs][smb_mapping][entries][per-second] != "" {
+    if ![logs_smb_mapping_not_set]
+    and [logs][smb_mapping][entries][per-second] != "" {
       mutate {
         replace => {
           "token_logs_smb_mapping.key" => "logs_smb_mapping_entries_per_second"
@@ -1487,7 +1813,8 @@ filter {
       on_error => "logs_software_not_set"
     }
 
-    if ![logs_software_not_set] and [logs][software][entries][per-second] != "" {
+    if ![logs_software_not_set]
+    and [logs][software][entries][per-second] != "" {
       mutate {
         replace => {
           "token_logs_software.key" => "logs_software_entries_per_second"
@@ -1603,7 +1930,8 @@ filter {
       on_error => "logs_traceroute_not_set"
     }
 
-    if ![logs_traceroute_not_set] and [logs][traceroute][entries][per-second] != "" {
+    if ![logs_traceroute_not_set]
+    and [logs][traceroute][entries][per-second] != "" {
       mutate {
         replace => {
           "token_logs_traceroute.key" => "logs_traceroute_entries_per_second"
@@ -2038,7 +2366,8 @@ filter {
       on_error => "logs_elasticsearch_not_set"
     }
 
-    if ![logs_elasticsearch_not_set] and [logs][elasticsearch_export][lag] != "" {
+    if ![logs_elasticsearch_not_set]
+    and [logs][elasticsearch_export][lag] != "" {
       mutate {
         replace => {
           "token_logs_elasticsearch.key" => "logs_elasticsearch_export_lag"
@@ -2496,7 +2825,7 @@ filter {
 
 
   }
-  
+
   #------------------------------------------------------------------------
   # CORELIGHT_METRICS_ZEEK_DOCTOR
 
@@ -2541,15 +2870,18 @@ filter {
 
     mutate {
       replace => {
-        "token_dns_half_duplex_orig.value" => "%{check.dns_half_duplex_orig.percent}"
+        "token_dns_half_duplex_orig.value" =>
+        "%{check.dns_half_duplex_orig.percent}"
       }
       on_error => "dns_half_duplex_orig_not_set"
     }
 
-    if ![dns_half_duplex_orig_not_set] and [check][dns_half_duplex_orig][percent] != "" {
+    if ![dns_half_duplex_orig_not_set]
+    and [check][dns_half_duplex_orig][percent] != "" {
       mutate {
         replace => {
-          "token_dns_half_duplex_orig.key" => "check_dns_half_duplex_orig_percent"
+          "token_dns_half_duplex_orig.key" =>
+          "check_dns_half_duplex_orig_percent"
         }
       }
 
@@ -2570,15 +2902,18 @@ filter {
 
     mutate {
       replace => {
-        "token_dns_half_duplex_resp.value" => "%{check.dns_half_duplex_resp.percent}"
+        "token_dns_half_duplex_resp.value" =>
+        "%{check.dns_half_duplex_resp.percent}"
       }
       on_error => "dns_half_duplex_resp_not_set"
     }
 
-    if ![dns_half_duplex_resp_not_set] and [check][dns_half_duplex_resp][percent] != "" {
+    if ![dns_half_duplex_resp_not_set]
+    and [check][dns_half_duplex_resp][percent] != "" {
       mutate {
         replace => {
-          "token_dns_half_duplex_resp.key" => "check_dns_half_duplex_resp_percent"
+          "token_dns_half_duplex_resp.key" =>
+          "check_dns_half_duplex_resp_percent"
         }
       }
 
@@ -2633,7 +2968,8 @@ filter {
       on_error => "remote_to_remote_not_set"
     }
 
-    if ![remote_to_remote_not_set] and [check][remote_to_remote][percent] != "" {
+    if ![remote_to_remote_not_set]
+    and [check][remote_to_remote][percent] != "" {
       mutate {
         replace => {
           "token_remote_to_remote.key" => "check_remote_to_remote_percent"
@@ -2686,15 +3022,18 @@ filter {
 
     mutate {
       replace => {
-        "token_tcp_byte_counts_wrong.value" => "%{check.tcp_byte_counts_wrong.percent}"
+        "token_tcp_byte_counts_wrong.value" =>
+        "%{check.tcp_byte_counts_wrong.percent}"
       }
       on_error => "tcp_byte_counts_wrong_not_set"
     }
 
-    if ![tcp_byte_counts_wrong_not_set] and [check][tcp_byte_counts_wrong][percent] != "" {
+    if ![tcp_byte_counts_wrong_not_set]
+    and [check][tcp_byte_counts_wrong][percent] != "" {
       mutate {
         replace => {
-          "token_tcp_byte_counts_wrong.key" => "check_tcp_byte_counts_wrong_percent"
+          "token_tcp_byte_counts_wrong.key" =>
+          "check_tcp_byte_counts_wrong_percent"
         }
       }
 
@@ -2749,7 +3088,8 @@ filter {
       on_error => "tcp_missed_bytes_not_set"
     }
 
-    if ![tcp_missed_bytes_not_set] and [check][tcp_missed_bytes][percent] != "" {
+    if ![tcp_missed_bytes_not_set]
+    and [check][tcp_missed_bytes][percent] != "" {
       mutate {
         replace => {
           "token_tcp_missed_bytes.key" => "check_tcp_missed_bytes_percent"
@@ -2778,7 +3118,8 @@ filter {
       on_error => "tcp_no_ssl_on_443_not_set"
     }
 
-    if ![tcp_no_ssl_on_443_not_set] and [check][tcp_no_ssl_on_443][percent] != "" {
+    if ![tcp_no_ssl_on_443_not_set]
+    and [check][tcp_no_ssl_on_443][percent] != "" {
       mutate {
         replace => {
           "token_tcp_no_ssl_on_443.key" => "check_tcp_no_ssl_on_443_percent"
@@ -2802,15 +3143,18 @@ filter {
 
     mutate {
       replace => {
-        "token_tcp_no_three_way_handshake.value" => "%{check.tcp_no_three_way_handshake.percent}"
+        "token_tcp_no_three_way_handshake.value" =>
+        "%{check.tcp_no_three_way_handshake.percent}"
       }
       on_error => "tcp_no_three_way_handshake_not_set"
     }
 
-    if ![tcp_no_three_way_handshake_not_set] and [check][tcp_no_three_way_handshake][percent] != "" {
+    if ![tcp_no_three_way_handshake_not_set]
+    and [check][tcp_no_three_way_handshake][percent] != "" {
       mutate {
         replace => {
-          "token_tcp_no_three_way_handshake.key" => "check_tcp_no_three_way_handshake_percent"
+          "token_tcp_no_three_way_handshake.key" =>
+          "check_tcp_no_three_way_handshake_percent"
         }
       }
 
@@ -2831,12 +3175,14 @@ filter {
 
     mutate {
       replace => {
-        "token_tcp_retransmissions.value" => "%{check.tcp_retransmissions.percent}"
+        "token_tcp_retransmissions.value" =>
+        "%{check.tcp_retransmissions.percent}"
       }
       on_error => "tcp_retransmissions_not_set"
     }
 
-    if ![tcp_retransmissions_not_set] and [check][tcp_retransmissions][percent] != "" {
+    if ![tcp_retransmissions_not_set]
+    and [check][tcp_retransmissions][percent] != "" {
       mutate {
         replace => {
           "token_tcp_retransmissions.key" => "check_tcp_retransmissions_percent"
@@ -2928,7 +3274,7 @@ filter {
       }
     }
 
-    #UDM > Target
+    # UDM > Target
     mutate {
       replace => {
         "endpoint_labels.value" => "%{endpoint}"
@@ -2967,7 +3313,7 @@ filter {
       }
     }
 
-    #UDM > Intermediary
+    # UDM > Intermediary
     mutate {
       replace => {
         "dce_rpc_intermediary.resource.name" => "%{named_pipe}"
@@ -2993,12 +3339,13 @@ filter {
     # UDM > Metadata
     mutate {
       replace => {
-        "token_metadata.description" => "operation '%{operation}' on '%{endpoint}' using named pipe [%{named_pipe}]"
+        "token_metadata.description" =>
+        "operation '%{operation}' on '%{endpoint}' using named pipe [%{named_pipe}]"
       }
       on_error => "description_not_set"
     }
 
-    #UDM > About
+    # UDM > About
 
     mutate {
       merge => {
@@ -3026,7 +3373,7 @@ filter {
         "token_security_result" => "dce_security_result"
       }
     }
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -3081,7 +3428,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4",
+      "PIM", "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -3167,14 +3515,55 @@ filter {
 
     mutate {
       convert => {
-        "rejected" => "boolean"
+        "rejected" => "string"
       }
       on_error => "rejected_conversion_error"
     }
 
     mutate {
-      rename => {
-        "rejected" => "token_network.dns.response"
+      replace => {
+        "rejected_labels.value" => "%{rejected}"
+      }
+      on_error => "rejected_not_found"
+    }
+    if ![rejected_not_found] and [rejected] != "" {
+      mutate {
+        replace => {
+          "rejected_labels.key" => "rejected"
+        }
+      }
+      mutate {
+        merge => {
+          "dns_about.labels" => "rejected_labels"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "rcode" => "string"
+      }
+      on_error => "rcode_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "check_rcode" => "%{rcode}"
+      }
+      on_error => "rcode_not_found"
+    }
+
+    if ![rcode_not_found] and [rcode] != "" {
+      mutate {
+        replace => {
+          "token_network.dns.response" => "true"
+        }
+      }
+      mutate {
+        convert => {
+          "token_network.dns.response" => "boolean"
+        }
+        on_error => "network_dns_response_not_found"
       }
     }
 
@@ -3224,10 +3613,13 @@ filter {
             convert => {
               "ttl" => "uinteger"
             }
+            on_error => "ttl_conversion_error"
           }
-          mutate {
-            rename => {
-              "ttl" => "token_answer.ttl"
+          if ![ttl_conversion_error] {
+            mutate {
+              rename => {
+                "ttl" => "token_answer.ttl"
+              }
             }
           }
           mutate {
@@ -3267,15 +3659,29 @@ filter {
 
     mutate {
       replace => {
+        "is_question_name_exist" => "false"
+      }
+    }
+
+    mutate {
+      replace => {
         "question_check" => "%{query}"
       }
       on_error => "query_not_found"
     }
-    mutate {
-      replace => {
-        "token_questions.name" => "%{query}"
+
+    if ![query_not_found] and [query] != "" and [query] =~ "^(.){1,255}$" {
+      mutate {
+        replace => {
+          "is_question_name_exist" => "true"
+        }
       }
-      on_error => "query_not_found"
+
+      mutate {
+        replace => {
+          "token_questions.name" => "%{query}"
+        }
+      }
     }
 
     mutate {
@@ -3498,10 +3904,11 @@ filter {
       on_error => "dns_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
-    # occasional DNS logs include no question, we drop them as they have no pratical usage
+    # Check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
+    # Occasional DNS logs include no question, we drop them as they have no pratical usage
     # UDM > Metadata > Event Type
-    if [principal_present] == "true" and [question_check] != "" {
+    if [principal_present] == "true" and [question_check] != ""
+    and [is_question_name_exist] == "true" {
       mutate {
         replace => {
           "token_metadata.event_type" => "NETWORK_DNS"
@@ -4221,7 +4628,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -4538,8 +4945,9 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
-    if [principal_present] == "true" and [target_present] == "true" and [principal_hostname_present] == "true" and [target_file_present] == "true" {
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    if [principal_present] == "true" and [target_present] == "true" and
+    [principal_hostname_present] == "true" and [target_file_present] == "true" {
       if ![action_not_set] {
         if [action] == "SMB::FILE_READ" {
           mutate {
@@ -4576,7 +4984,8 @@ filter {
             }
           }
         }
-        else if [action] == "SMB::FILE_RENAME" and [src_file_present] == "true" {
+        else if [action] == "SMB::FILE_RENAME"
+        and [src_file_present] == "true" {
           mutate {
             replace => {
               "token_metadata.event_type" => "FILE_MOVE"
@@ -4740,7 +5149,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -5153,7 +5562,7 @@ filter {
       on_error => "var_token_intermediary_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_SMTP exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_SMTP exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -5232,7 +5641,7 @@ filter {
       on_error => "var_token_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_SMTP exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_SMTP exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -5342,20 +5751,23 @@ filter {
     }
     mutate {
       replace => {
-        "token_target.location.country_or_region" => "%{remote_location.country_code}: %{remote_location.region}"
+        "token_target.location.country_or_region" =>
+        "%{remote_location.country_code}: %{remote_location.region}"
       }
       on_error => "location_not_found"
     }
     if [location_not_found] {
       mutate {
         replace => {
-          "token_target.location.country_or_region" => "%{remote_location.country_code}"
+          "token_target.location.country_or_region" =>
+          "%{remote_location.country_code}"
         }
         on_error => "country_code_not_found"
       }
       mutate {
         replace => {
-          "token_target.location.country_or_region" => "%{remote_location.region}"
+          "token_target.location.country_or_region" =>
+          "%{remote_location.region}"
         }
         on_error => "region_not_found"
       }
@@ -5376,7 +5788,8 @@ filter {
     }
     mutate {
       rename => {
-        "remote_location.latitude" => "token_target.location.region_coordinates.latitude"
+        "remote_location.latitude" =>
+        "token_target.location.region_coordinates.latitude"
       }
     }
 
@@ -5388,7 +5801,8 @@ filter {
     }
     mutate {
       rename => {
-        "remote_location.longitude" => "token_target.location.region_coordinates.longitude"
+        "remote_location.longitude" =>
+        "token_target.location.region_coordinates.longitude"
       }
     }
 
@@ -5530,7 +5944,8 @@ filter {
     }
     mutate {
       replace => {
-        "token_extensions.auth.auth_details" => "auth_attempts: %{auth_attempts}"
+        "token_extensions.auth.auth_details" =>
+        "auth_attempts: %{auth_attempts}"
       }
       on_error => "auth_attempts_not_found"
     }
@@ -5692,7 +6107,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A client wasn't adhering to expectations of SSH either through server exploit or by the client and server switching to a protocol other than SSH after enctyption begins"
+            "inf_security_result.description" =>
+            "A client wasn't adhering to expectations of SSH either through server exploit or by the client and server switching to a protocol other than SSH after enctyption begins"
           }
         }
       }
@@ -5704,7 +6120,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "Agent Forwarding is requested by tge Client"
+            "inf_security_result.description" =>
+            "Agent Forwarding is requested by tge Client"
           }
         }
       }
@@ -5716,7 +6133,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client authenticated with an automated password tool (like sshpass)"
+            "inf_security_result.description" =>
+            "The client authenticated with an automated password tool (like sshpass)"
           }
         }
       }
@@ -5728,7 +6146,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client is a script automated utility and not driven by a user"
+            "inf_security_result.description" =>
+            "The client is a script automated utility and not driven by a user"
           }
         }
       }
@@ -5740,7 +6159,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The server sent the client a pre-authentication banner, likely for legal reasons"
+            "inf_security_result.description" =>
+            "The server sent the client a pre-authentication banner, likely for legal reasons"
           }
         }
       }
@@ -5752,7 +6172,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A client made a number of authentication attempts that exceeded some configured, pre-connection threshold"
+            "inf_security_result.description" =>
+            "A client made a number of authentication attempts that exceeded some configured, pre-connection threshold"
           }
         }
       }
@@ -5764,7 +6185,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A client made a number of authentication attempts that exceeded some configured, pre-connection threshold"
+            "inf_security_result.description" =>
+            "A client made a number of authentication attempts that exceeded some configured, pre-connection threshold"
           }
         }
       }
@@ -5776,7 +6198,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client already has an entry in its known_hosts file for this server"
+            "inf_security_result.description" =>
+            "The client already has an entry in its known_hosts file for this server"
           }
         }
       }
@@ -5788,19 +6211,22 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client did not have an entry in its known_hosts file for this server"
+            "inf_security_result.description" =>
+            "The client did not have an entry in its known_hosts file for this server"
           }
         }
       }
       if [inference] == "IPWA" {
         mutate {
           replace => {
-            "inf_security_result.summary" => "Interactive Password Authentication"
+            "inf_security_result.summary" =>
+            "Interactive Password Authentication"
           }
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client interactively typed their password to authenticate"
+            "inf_security_result.description" =>
+            "The client interactively typed their password to authenticate"
           }
         }
       }
@@ -5812,7 +6238,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "An interactive session occurred in which the client set user-driven keystrokes to the server"
+            "inf_security_result.description" =>
+            "An interactive session occurred in which the client set user-driven keystrokes to the server"
           }
         }
       }
@@ -5824,7 +6251,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A file transfer occurred in which the server sent a sequence of bytes to the client"
+            "inf_security_result.description" =>
+            "A file transfer occurred in which the server sent a sequence of bytes to the client"
           }
         }
       }
@@ -5836,7 +6264,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A file transfer occurred in which the client sent a sequence of bytes to the server. Large file are identified dynamically based on trains of MTU-sized packets"
+            "inf_security_result.description" =>
+            "A file transfer occurred in which the client sent a sequence of bytes to the server. Large file are identified dynamically based on trains of MTU-sized packets"
           }
         }
       }
@@ -5848,7 +6277,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The server required a second form of authentication (a code) after password or public key was accepted, and the client successfully provided it"
+            "inf_security_result.description" =>
+            "The server required a second form of authentication (a code) after password or public key was accepted, and the client successfully provided it"
           }
         }
       }
@@ -5860,7 +6290,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client successfully authenticated using the None method"
+            "inf_security_result.description" =>
+            "The client successfully authenticated using the None method"
           }
         }
       }
@@ -5872,7 +6303,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The -N flag was used in SSH authentication"
+            "inf_security_result.description" =>
+            "The -N flag was used in SSH authentication"
           }
         }
       }
@@ -5884,7 +6316,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client automatically authenticated using pubkey authentication"
+            "inf_security_result.description" =>
+            "The client automatically authenticated using pubkey authentication"
           }
         }
       }
@@ -5896,7 +6329,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The Reverse session is initiated from the server back to the client"
+            "inf_security_result.description" =>
+            "The Reverse session is initiated from the server back to the client"
           }
         }
       }
@@ -5908,7 +6342,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The inititation of the Reverse session happened very early in the packet stream, indicating automation"
+            "inf_security_result.description" =>
+            "The inititation of the Reverse session happened very early in the packet stream, indicating automation"
           }
         }
       }
@@ -5920,7 +6355,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "Keystrokes are detected within the Reverse tunnel"
+            "inf_security_result.description" =>
+            "Keystrokes are detected within the Reverse tunnel"
           }
         }
       }
@@ -5932,7 +6368,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The Reverse Tunnel login has succeeded"
+            "inf_security_result.description" =>
+            "The Reverse Tunnel login has succeeded"
           }
         }
       }
@@ -5944,7 +6381,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client connected with -R flag, which provisions the port to be used for a Reverse Session set up at any future time"
+            "inf_security_result.description" =>
+            "The client connected with -R flag, which provisions the port to be used for a Reverse Session set up at any future time"
           }
         }
       }
@@ -5956,7 +6394,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client scanned authentication method with the server and then disconnected"
+            "inf_security_result.description" =>
+            "The client scanned authentication method with the server and then disconnected"
           }
         }
       }
@@ -5968,7 +6407,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The client exchanged capabilities with the server and then disconnected"
+            "inf_security_result.description" =>
+            "The client exchanged capabilities with the server and then disconnected"
           }
         }
       }
@@ -5980,7 +6420,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A file transfer occurred in which the server sent a sequence of bytes to the client"
+            "inf_security_result.description" =>
+            "A file transfer occurred in which the server sent a sequence of bytes to the client"
           }
         }
       }
@@ -5992,7 +6433,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A file transfer occurred in which the client sent a sequence of bytes to the server"
+            "inf_security_result.description" =>
+            "A file transfer occurred in which the client sent a sequence of bytes to the server"
           }
         }
       }
@@ -6004,7 +6446,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A client and server didn't exchange encrypted packets but the client wasn't a version or capabilities scanner"
+            "inf_security_result.description" =>
+            "A client and server didn't exchange encrypted packets but the client wasn't a version or capabilities scanner"
           }
         }
       }
@@ -6016,7 +6459,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "A client exchanged version strings with the server and than disconnected"
+            "inf_security_result.description" =>
+            "A client exchanged version strings with the server and than disconnected"
           }
         }
       }
@@ -6028,7 +6472,8 @@ filter {
         }
         mutate {
           replace => {
-            "inf_security_result.description" => "The authentication method is not determinated or is unknown"
+            "inf_security_result.description" =>
+            "The authentication method is not determinated or is unknown"
           }
         }
       }
@@ -6040,7 +6485,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -6065,7 +6510,7 @@ filter {
 
   else if [_path] == "irc" {
 
-    # UDM > Principal   
+    # UDM > Principal
     mutate {
       replace => {
         "token_principal.user.user_display_name" => "%{nick}"
@@ -6179,7 +6624,7 @@ filter {
       on_error => "irc_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -6710,7 +7155,8 @@ filter {
     # UDM > Security Results
     mutate {
       replace => {
-        "rdp_security_result.description" => "%{result} connection with security protocol %{security_protocol}"
+        "rdp_security_result.description" =>
+        "%{result} connection with security protocol %{security_protocol}"
       }
       on_error => "rdp_security_result_description_field_not_set"
     }
@@ -6729,7 +7175,7 @@ filter {
       on_error => "rdp_security_result_not_set"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -6772,91 +7218,104 @@ filter {
       if [conn_state] == "S0" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection attempt seen, no reply"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection attempt seen, no reply"
           }
         }
       }
       else if [conn_state] == "S1" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection established, not terminated"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection established, not terminated"
           }
         }
       }
       else if [conn_state] == "S2" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection established and close attempt by originator seen (but no reply from responder)"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection established and close attempt by originator seen (but no reply from responder)"
           }
         }
       }
       else if [conn_state] == "S3" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection established and close attempt by responder seen (but no reply from originator)"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection established and close attempt by responder seen (but no reply from originator)"
           }
         }
       }
       else if [conn_state] == "SF" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Normal SYN/FIN completion"
+            "token_metadata.description" =>
+            "%{conn_state}: Normal SYN/FIN completion"
           }
         }
       }
       else if [conn_state] == "REJ" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection attempt rejected"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection attempt rejected"
           }
         }
       }
       else if [conn_state] == "RSTO" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Connection established, originator aborted (sent a RST)"
+            "token_metadata.description" =>
+            "%{conn_state}: Connection established, originator aborted (sent a RST)"
           }
         }
       }
       else if [conn_state] == "RSTOS0" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Originator sent a SYN followed by a RST, we never saw a SYN-ACK from the responder"
+            "token_metadata.description" =>
+            "%{conn_state}: Originator sent a SYN followed by a RST, we never saw a SYN-ACK from the responder"
           }
         }
       }
       else if [conn_state] == "RSTOSH" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Responder sent a SYN ACK followed by a RST, we never saw a SYN from the (purported) originator"
+            "token_metadata.description" =>
+            "%{conn_state}: Responder sent a SYN ACK followed by a RST, we never saw a SYN from the (purported) originator"
           }
         }
       }
       else if [conn_state] == "RSTR" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Established, responder aborted"
+            "token_metadata.description" =>
+            "%{conn_state}: Established, responder aborted"
           }
         }
       }
       else if [conn_state] == "SH" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Originator sent a SYN followed by a FIN, we never saw a SYN ACK from the responder (hence the connection was “half” open)"
+            "token_metadata.description" =>
+            "%{conn_state}: Originator sent a SYN followed by a FIN, we never saw a SYN ACK from the responder (hence the connection was “half” open)"
           }
         }
       }
       else if [conn_state] == "SHR" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: Responder sent a SYN ACK followed by a FIN, we never saw a SYN from the originator"
+            "token_metadata.description" =>
+            "%{conn_state}: Responder sent a SYN ACK followed by a FIN, we never saw a SYN from the originator"
           }
         }
       }
       else if [conn_state] == "OTH" {
         mutate {
           replace => {
-            "token_metadata.description" => "%{conn_state}: No SYN seen, just midstream traffic (a partial connection that was not later closed)"
+            "token_metadata.description" =>
+            "%{conn_state}: No SYN seen, just midstream traffic (a partial connection that was not later closed)"
           }
         }
       }
@@ -6874,7 +7333,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -6941,7 +7401,7 @@ filter {
       else {
         mutate {
           replace => {
-            "token_network.application_protocol" => 
+            "token_network.application_protocol" =>
             "UNKNOWN_APPLICATION_PROTOCOL"
           }
         }
@@ -7647,6 +8107,231 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
+    # UDM > additional
+    mutate {
+      convert => {
+        "orig_ep_cid" => "string"
+      }
+      on_error => "orig_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "orig_ep_cid_label.value.string_value" => "%{orig_ep_cid}"
+      }
+      on_error => "orig_ep_cid_not_found"
+    }
+
+    if ![orig_ep_cid_not_found] and
+      [orig_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "orig_ep_cid_label.key" => "orig_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "orig_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "orig_ep_source" => "string"
+      }
+      on_error => "orig_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "orig_ep_source_label.value.string_value" => "%{orig_ep_source}"
+      }
+      on_error => "orig_ep_source_not_found"
+    }
+
+    if ![orig_ep_source_not_found] and
+      [orig_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "orig_ep_source_label.key" => "orig_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "orig_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "orig_ep_status" => "string"
+      }
+      on_error => "orig_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "orig_ep_status_label.value.string_value" => "%{orig_ep_status}"
+      }
+      on_error => "orig_ep_status_not_found"
+    }
+
+    if ![orig_ep_status_not_found] and
+      [orig_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "orig_ep_status_label.key" => "orig_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "orig_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "orig_ep_uid" => "string"
+      }
+      on_error => "orig_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "orig_ep_uid_label.value.string_value" => "%{orig_ep_uid}"
+      }
+      on_error => "orig_ep_uid_not_found"
+    }
+
+    if ![orig_ep_uid_not_found] and
+      [orig_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "orig_ep_uid_label.key" => "orig_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "orig_ep_uid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "resp_ep_cid" => "string"
+      }
+      on_error => "resp_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "resp_ep_cid_label.value.string_value" => "%{resp_ep_cid}"
+      }
+      on_error => "resp_ep_cid_not_found"
+    }
+
+    if ![resp_ep_cid_not_found] and
+      [resp_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "resp_ep_cid_label.key" => "resp_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "resp_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "resp_ep_source" => "string"
+      }
+      on_error => "resp_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "resp_ep_source_label.value.string_value" => "%{resp_ep_source}"
+      }
+      on_error => "resp_ep_source_not_found"
+    }
+
+    if ![resp_ep_source_not_found] and
+      [resp_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "resp_ep_source_label.key" => "resp_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "resp_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "resp_ep_status" => "string"
+      }
+      on_error => "resp_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "resp_ep_status_label.value.string_value" => "%{resp_ep_status}"
+      }
+      on_error => "resp_ep_status_not_found"
+    }
+
+    if ![resp_ep_status_not_found] and
+      [resp_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "resp_ep_status_label.key" => "resp_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "resp_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "resp_ep_uid" => "string"
+      }
+      on_error => "resp_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "resp_ep_uid_label.value.string_value" => "%{resp_ep_uid}"
+      }
+      on_error => "resp_ep_uid_not_found"
+    }
+
+    if ![resp_ep_uid_not_found] and
+      [resp_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "resp_ep_uid_label.key" => "resp_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "resp_ep_uid_label"
+        }
+      }
+    }
+
     # UDM > Security Results
     mutate {
       convert => {
@@ -7768,7 +8453,7 @@ filter {
       on_error => "failed_to_merge_token_intermediary"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -8188,6 +8873,56 @@ filter {
       }
     }
 
+    if ![source_not_found] and [source] =~ "(?i)ssl"
+    and ![mime_type_not_found] {
+      if [mime_type] == "application/x-x509-user-cert" {
+        if ![md5_not_set] and [md5] =~ "^[a-fA-F0-9]{32}$" {
+          mutate {
+            replace => {
+              "token_network.tls.client.certificate.md5" => "%{md5}"
+            }
+          }
+        }
+        if ![sha256_not_set] and [sha256] =~ "^[a-fA-F0-9]{64}$" {
+          mutate {
+            replace => {
+              "token_network.tls.client.certificate.sha256" => "%{sha256}"
+            }
+          }
+        }
+        if ![sha1_not_set] and [sha1] =~ "^[a-fA-F0-9]{40}$" {
+          mutate {
+            replace => {
+              "token_network.tls.client.certificate.sha1" => "%{sha1}"
+            }
+          }
+        }
+      }
+      else if [mime_type] == "application/x-x509-ca-cert" {
+        if ![md5_not_set] and [md5] =~ "^[a-fA-F0-9]{32}$" {
+          mutate {
+            replace => {
+              "token_network.tls.server.certificate.md5" => "%{md5}"
+            }
+          }
+        }
+        if ![sha256_not_set] and [sha256] =~ "^[a-fA-F0-9]{64}$" {
+          mutate {
+            replace => {
+              "token_network.tls.server.certificate.sha256" => "%{sha256}"
+            }
+          }
+        }
+        if ![sha1_not_set] and [sha1] =~ "^[a-fA-F0-9]{40}$" {
+          mutate {
+            replace => {
+              "token_network.tls.server.certificate.sha1" => "%{sha1}"
+            }
+          }
+        }
+      }
+    }
+
     mutate {
       convert => {
         "local_orig" => "string"
@@ -8326,17 +9061,15 @@ filter {
     }
 
     mutate {
-      rename => {
-        "token_about" => "files_about"
+      merge => {
+        "token_about.file.names" => "extracted"
       }
+      on_error => "extracted_ele_not_found"
     }
 
-    for index, extractedele in extracted {
-      mutate {
-        merge => {
-          "files_about.file.names" => "extractedele"
-        }
-        on_error => "extracted_ele_not_found"
+    mutate {
+      rename => {
+        "token_about" => "files_about"
       }
     }
 
@@ -8375,6 +9108,62 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
+    # UDM > additional
+    mutate {
+      convert => {
+        "vlan" => "string"
+      }
+      on_error => "vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "vlan_label.value.string_value" => "%{vlan}"
+      }
+      on_error => "vlan_not_found"
+    }
+
+    if ![vlan_not_found] and [vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "vlan_label.key" => "vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "vlan_inner" => "string"
+      }
+      on_error => "vlan_inner_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "vlan_inner_label.value.string_value" => "%{vlan_inner}"
+      }
+      on_error => "vlan_inner_not_found"
+    }
+
+    if ![vlan_inner_not_found] and
+      [vlan_inner_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "vlan_inner_label.key" => "vlan_inner"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "vlan_inner_label"
+        }
+      }
+    }
+
     # UDM > Security Result
 
     mutate {
@@ -8384,7 +9173,7 @@ filter {
       on_error => "failed_to_merge_security_result"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and  [target_present] == "true" {
       mutate {
         replace => {
@@ -8446,6 +9235,112 @@ filter {
       }
     }
 
+    mutate {
+      replace => {
+        "resp_vulnerabiliti_details.cve_id" => "%{resp_vulnerable_host.cve}"
+      }
+      on_error => "resp_vulnerable_host_cve_not_found"
+    }
+
+    mutate {
+      replace => {
+        "resp_vulnerabiliti_details.cve_description" =>
+        "%{resp_vulnerable_host.source}"
+      }
+      on_error => "resp_vulnerable_host_source_not_found"
+    }
+
+    mutate {
+      convert => {
+        "resp_vulnerable_host.criticality" => "string"
+      }
+      on_error => "resp_vulnerable_host_criticality_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "_" => "%{resp_vulnerable_host.criticality}"
+      }
+      on_error => "resp_vulnerable_host_criticality_not_found"
+    }
+
+    if ![resp_vulnerable_host_criticality_not_found] {
+      if [resp_vulnerable_host][criticality] =~ "(?i)Critical"
+      or [resp_vulnerable_host][criticality] == "4" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "CRITICAL"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)High"
+      or [resp_vulnerable_host][criticality] == "3" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "HIGH"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Low"
+      or [resp_vulnerable_host][criticality] == "1" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "LOW"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Medium"
+      or [resp_vulnerable_host][criticality] == "2" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "MEDIUM"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Unknown_Severity"
+      or [resp_vulnerable_host][criticality] == "0" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" =>
+            "UNKNOWN_SEVERITY"
+          }
+        }
+      }
+
+      mutate {
+        replace => {
+          "resp_vulnerabiliti_details.severity_details" =>
+          "%{resp_vulnerable_host.criticality}"
+        }
+      }
+    }
+
+    mutate {
+      merge => {
+        "token_target.asset.vulnerabilities" => "resp_vulnerabiliti_details"
+      }
+      on_error => "failed_to_merge_resp_vulnerabiliti_details"
+    }
+
+    mutate {
+      replace => {
+        "token_target.asset.hostname" => "%{resp_vulnerable_host.hostname}"
+      }
+      on_error => "resp_vulnerable_host_hostname_uid_not_found"
+    }
+
+    mutate {
+      replace => {
+        "token_target.asset.network_domain" =>
+        "%{resp_vulnerable_host.machine_domain}"
+      }
+      on_error => "resp_vulnerable_host_machine_domain_not_found"
+    }
+
+    mutate {
+      replace => {
+        "token_target.asset.platform_software.platform_version" =>
+        "%{resp_vulnerable_host.os_version}"
+      }
+      on_error => "resp_vulnerable_host_os_version_not_found"
+    }
+
     # UDM > Security Result
 
     mutate {
@@ -8475,46 +9370,46 @@ filter {
         }
       }
     }
-    
+
     if ![severity_level_not_found] {
       if [severity][level] in ["0", "1", "2"] {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "CRITICAL"
           }
         }
       }
       else if [severity][level] == "3" {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "ERROR"
           }
         }
       }
       else if [severity][level] == "4" {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "HIGH"
           }
         }
       }
       else if [severity][level] == "5" {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "LOW"
           }
         }
       }
       else if [severity][level] == "6" {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "INFORMATIONAL"
           }
         }
       }
       else {
         mutate{
-          replace => {  
+          replace => {
             "token_security_result.severity" => "UNKNOWN_SEVERITY"
           }
         }
@@ -8527,8 +9422,6 @@ filter {
       }
       on_error => "severity_name_not_found"
     }
-
-
 
     mutate {
       replace => {
@@ -8634,7 +9527,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -8690,6 +9584,112 @@ filter {
         }
         on_error => "id_orig_h_not_founc"
       }
+    }
+
+    mutate {
+      replace => {
+        "orig_vulnerabiliti_details.cve_id" => "%{orig_vulnerable_host.cve}"
+      }
+      on_error => "orig_vulnerable_host_cve_not_found"
+    }
+
+    mutate {
+      replace => {
+        "orig_vulnerabiliti_details.cve_description" =>
+        "%{orig_vulnerable_host.source}"
+      }
+      on_error => "orig_vulnerable_host_source_not_found"
+    }
+
+    mutate {
+      convert => {
+        "orig_vulnerable_host.criticality" => "string"
+      }
+      on_error => "orig_vulnerable_host_criticality_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "_" => "%{orig_vulnerable_host.criticality}"
+      }
+      on_error => "orig_vulnerable_host_criticality_not_found"
+    }
+
+    if ![orig_vulnerable_host_criticality_not_found] {
+      if [orig_vulnerable_host][criticality] =~ "(?i)Critical"
+      or [orig_vulnerable_host][criticality] == "4" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "CRITICAL"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)High"
+      or [orig_vulnerable_host][criticality] == "3" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "HIGH"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Low"
+      or [orig_vulnerable_host][criticality] == "1" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "LOW"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Medium"
+      or [orig_vulnerable_host][criticality] == "2" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "MEDIUM"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Unknown_Severity"
+      or [orig_vulnerable_host][criticality] == "0" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" =>
+            "UNKNOWN_SEVERITY"
+          }
+        }
+      }
+
+      mutate {
+        replace => {
+          "orig_vulnerabiliti_details.severity_details" =>
+          "%{orig_vulnerable_host.criticality}"
+        }
+      }
+    }
+
+    mutate {
+      merge => {
+        "token_principal.asset.vulnerabilities" => "orig_vulnerabiliti_details"
+      }
+      on_error => "failed_to_merge_orig_vulnerabiliti_details"
+    }
+
+    mutate {
+      replace => {
+        "token_principal.asset.hostname" => "%{orig_vulnerable_host.hostname}"
+      }
+      on_error => "orig_vulnerable_host_hostname_uid_not_found"
+    }
+
+    mutate {
+      replace => {
+        "token_principal.asset.network_domain" =>
+        "%{orig_vulnerable_host.machine_domain}"
+      }
+      on_error => "orig_vulnerable_host_machine_domain_not_found"
+    }
+
+    mutate {
+      replace => {
+        "token_principal.asset.platform_software.platform_version" =>
+        "%{orig_vulnerable_host.os_version}"
+      }
+      on_error => "orig_vulnerable_host_os_version_not_found"
     }
 
     # UDM > About
@@ -8835,7 +9835,7 @@ filter {
     if [country_not_found] {
       mutate {
         replace => {
-          "token_about.location.country_or_region" => 
+          "token_about.location.country_or_region" =>
           "%{remote_location.country_code}"
         }
         on_error => "country_not_found"
@@ -8866,7 +9866,8 @@ filter {
 
     mutate {
       rename => {
-        "remote_location.latitude" => "token_about.location.region_coordinates.latitude"
+        "remote_location.latitude" =>
+        "token_about.location.region_coordinates.latitude"
       }
       on_error => "remote_location_not_found"
     }
@@ -8880,7 +9881,8 @@ filter {
 
     mutate {
       rename => {
-        "remote_location.longitude" => "token_about.location.region_coordinates.longitude"
+        "remote_location.longitude" =>
+        "token_about.location.region_coordinates.longitude"
       }
       on_error => "remote_location_not_found"
     }
@@ -8898,7 +9900,66 @@ filter {
       on_error => "failed_to_merge_token_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # UDM > additional
+    mutate {
+      convert => {
+        "orig_vulnerable_host.host_uid" => "string"
+      }
+      on_error => "orig_vulnerable_host_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "orig_vulnerable_host_uid_label.value.string_value" =>
+        "%{orig_vulnerable_host.host_uid}"
+      }
+      on_error => "orig_vulnerable_host_uid_not_found"
+    }
+
+    if ![orig_vulnerable_host_uid_not_found] and
+      [orig_vulnerable_host_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "orig_vulnerable_host_uid_label.key" => "orig_vulnerable_host_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "orig_vulnerable_host_uid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "resp_vulnerable_host.host_uid" => "string"
+      }
+      on_error => "resp_vulnerable_host_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "resp_vulnerable_host_uid_label.value.string_value" =>
+        "%{resp_vulnerable_host.host_uid}"
+      }
+      on_error => "resp_vulnerable_host_uid_not_found"
+    }
+
+    if ![resp_vulnerable_host_uid_not_found] and
+      [resp_vulnerable_host_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "resp_vulnerable_host_uid_label.key" => "resp_vulnerable_host_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "resp_vulnerable_host_uid_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -8916,7 +9977,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # suricata
+  # Suricata
 
   else if [_path] == "suricata_corelight" {
 
@@ -9149,6 +10210,60 @@ filter {
       }
     }
 
+    base64 {
+      source => "payload"
+      target => "payload_decoded"
+      encoding => "Standard"
+      on_error => "payload_decode_failure"
+    }
+    mutate {
+      replace => {
+        "token_payload_dec.value" => "%{payload_decoded}"
+      }
+      on_error => "payload_not_set"
+    }
+
+    if ![payload_not_set] and [payload] != "" {
+      mutate {
+        replace => {
+          "token_payload_dec.key" => "payload_decoded"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_about.labels" => "token_payload_dec"
+        }
+      }
+    }
+
+    base64 {
+      source => "packet"
+      target => "packet_decoded"
+      encoding => "Standard"
+      on_error => "packet_decode_failure"
+    }
+    mutate {
+      replace => {
+        "token_packet_dec.value" => "%{packet_decoded}"
+      }
+      on_error => "packet_not_set"
+    }
+
+    if ![packet_not_set] and [packet] != "" {
+      mutate {
+        replace => {
+          "token_packet_dec.key" => "packet_decoded"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_about.labels" => "token_packet_dec"
+        }
+      }
+    }
+
     mutate {
       replace => {
         "orig_host_uid.value" => "%{orig_vulnerable_host.host_uid}"
@@ -9230,14 +10345,6 @@ filter {
         "token_metadata.product_log_id" => "%{suri_id}"
       }
       on_error => "suri_id_not_found"
-    }
-
-    # UDM > Security Result
-
-    mutate {
-      replace => {
-        "token_security_result.severity" => "INFORMATIONAL"
-      }
     }
 
     mutate {
@@ -9347,32 +10454,176 @@ filter {
 
     mutate {
       replace => {
+        "alert.severity" => "%{alert.severity}"
+      }
+      on_error => "severity_not_found"
+    }
+
+    if ![severity_not_found] {
+      if [alert][severity] == "1" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "CRITICAL"
+          }
+        }
+      }
+      else if [alert][severity] == "2" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "HIGH"
+          }
+        }
+      }
+      else if [alert][severity] == "3" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "MEDIUM"
+          }
+        }
+      }
+      else if [alert][severity] == "4" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "LOW"
+          }
+        }
+      }
+
+      mutate {
+        convert => {
+          "alert.severity" => "float"
+        }
+        on_error => "severity_not_found"
+      }
+
+      mutate {
+        rename => {
+          "alert.severity" => "token_alert_severity.value.number_value"
+        }
+        on_error => "risk_score_not_found"
+      }
+
+      mutate {
+        replace => {
+          "token_alert_severity.key" => "alert_severity"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_additional.fields" => "token_alert_severity"
+        }
+        on_error => "alert_severity_not_found"
+      }
+    }
+    mutate {
+      replace => {
         "token_security_result.severity_details" => "%{alert.severity}"
       }
       on_error => "alert_severity_not_found"
     }
 
+    grok {
+      match => {
+        "alert.rule" =>
+        "signature_severity (?P<signature_severity>Critical|Major|Minor|Informational)"
+      }
+      overwrite => ["signature_severity"]
+      on_error => "signature_severity_not_found"
+    }
+
+    if ![signature_severity_not_found] {
+
+      if [signature_severity] == "Critical" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "CRITICAL"
+          }
+        }
+      }else if [signature_severity] == "Major" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "MEDIUM"
+          }
+        }
+      }
+      else if [signature_severity] == "Minor" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "LOW"
+          }
+        }
+      }
+      else if [signature_severity] == "Informational" {
+        mutate{
+          replace => {
+            "token_security_result.severity" => "INFORMATIONAL"
+          }
+        }
+      }
+
+      mutate {
+        replace => {
+          "token_security_result.severity_details" => "%{signature_severity}"
+        }
+      }
+    }
+
     for alertmetadatainfo in alert.metadata {
       mutate {
         replace => {
-          "token_alert_metadata_info" => ""
+          "temp_array" => ""
         }
       }
-
       mutate {
-        replace => {
-          "token_alert_metadata_info.value" => "%{alertmetadatainfo}"
-        }
-        on_error => "alert_metadata_info_not_set"
-      }
-
-      if ![alert_metadata_info_not_set] and [alertmetadatainfo] != "" {
-        mutate {
           replace => {
-            "token_alert_metadata_info.key" => "alert_metadata"
+            "token_alert_metadata_info" => ""
+          }
+        }
+      if [alertmetadatainfo] =~ ":" {
+        mutate {
+          split => {
+            source => "alertmetadatainfo"
+            separator => ":"
+            target => "temp_array"
           }
         }
 
+        mutate {
+          replace => {
+            "token_alert_metadata_info.value" => "%{temp_array.1}"
+          }
+          on_error => "alert_metadata_info_not_set"
+        }
+
+        if ![alert_metadata_info_not_set] and
+        [token_alert_metadata_info][value] != "" {
+          mutate {
+            replace => {
+              "token_alert_metadata_info.key" => "%{temp_array.0}"
+            }
+          }
+        }
+      }
+      else {
+        mutate {
+          replace => {
+            "token_alert_metadata_info.value" => "%{alertmetadatainfo}"
+          }
+          on_error => "alert_metadata_info_not_set"
+        }
+
+        if ![alert_metadata_info_not_set] and
+        [token_alert_metadata_info][value] != "" {
+          mutate {
+            replace => {
+              "token_alert_metadata_info.key" => "alert_metadata"
+            }
+          }
+        }
+      }
+      if ![alert_metadata_info_not_set] and
+      [token_alert_metadata_info][value] != "" {
         mutate {
           merge => {
             "token_security_result.detection_fields" =>
@@ -9408,6 +10659,398 @@ filter {
             "token_security_result.detection_fields" =>
             "token_metadata_info"
           }
+        }
+      }
+    }
+
+    mutate {
+      replace => {
+        "token_security_result.description" => "%{alert.rule}"
+      }
+      on_error => "alert_rule_not_found"
+    }
+
+    grok {
+      match => {
+        "alert.rule" => [
+          '%{GREEDYDATA:_}content:\\"%{GREEDYDATA:rule_content}\\"'
+        ]
+      }
+      overwrite => ["_"]
+      on_error => "alert_rule_content_not_found"
+    }
+
+    grok {
+      match => {
+        "alert.rule" => [
+          '%{GREEDYDATA:_}metadata:%{DATA:rule_metadata};'
+        ]
+      }
+      on_error => "alert_rule_metadata_not_found"
+      overwrite => ["_"]
+    }
+
+    if ![alert_rule_metadata_not_found] {
+      mutate {
+        gsub => [rule_metadata, ", ", "#"]
+      }
+
+      kv {
+        source => "rule_metadata"
+        field_split => "#"
+        value_split => " "
+        on_error => "rule_metadata_not_found"
+      }
+
+      mutate {
+        convert => {
+          "attack_target" => "string"
+        }
+        on_error => "alert_rule_attack_target_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "alert_rule_attack_target_label.value" => "%{attack_target}"
+        }
+        on_error => "alert_rule_attack_target_not_found"
+      }
+
+      if ![alert_rule_attack_target_not_found] and
+        [alert_rule_attack_target_label][value] != "" {
+        mutate {
+          replace => {
+            "alert_rule_attack_target_label.key" => "alert_rule_attack_target"
+          }
+        }
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" =>
+            "alert_rule_attack_target_label"
+          }
+          remove_field => ["alert_rule_attack_target_label"]
+        }
+      }
+
+      mutate {
+        convert => {
+          "created_at" => "string"
+        }
+        on_error => "alert_rule_created_at_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "alert_rule_created_at_label.value" => "%{created_at}"
+        }
+        on_error => "alert_rule_created_at_not_found"
+      }
+
+      if ![alert_rule_created_at_not_found] and
+        [alert_rule_created_at_label][value] != "" {
+        mutate {
+          replace => {
+            "alert_rule_created_at_label.key" => "alert_rule_created_at"
+          }
+        }
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" =>
+            "alert_rule_created_at_label"
+          }
+          remove_field => ["alert_rule_created_at_label"]
+        }
+      }
+
+      mutate {
+        convert => {
+          "deployment" => "string"
+        }
+        on_error => "alert_rule_deployment_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "alert_rule_deployment_label.value" => "%{deployment}"
+        }
+        on_error => "alert_rule_deployment_not_found"
+      }
+
+      if ![alert_rule_deployment_not_found] and
+        [alert_rule_deployment_label][value] != "" {
+        mutate {
+          replace => {
+            "alert_rule_deployment_label.key" => "alert_rule_deployment"
+          }
+        }
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" =>
+            "alert_rule_deployment_label"
+          }
+          remove_field => ["alert_rule_deployment_label"]
+        }
+      }
+
+      mutate {
+        convert => {
+          "performance_impact" => "string"
+        }
+        on_error => "alert_rule_performance_impact_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "alert_rule_performance_impact_label.value" =>
+          "%{performance_impact}"
+        }
+        on_error => "alert_rule_performance_impact_not_found"
+      }
+
+      if ![alert_rule_performance_impact_not_found] and
+        [alert_rule_performance_impact_label][value] != "" {
+        mutate {
+          replace => {
+            "alert_rule_performance_impact_label.key" =>
+            "alert_rule_performance_impact"
+          }
+        }
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" =>
+            "alert_rule_performance_impact_label"
+          }
+          remove_field => ["alert_rule_performance_impact_label"]
+        }
+      }
+
+      mutate {
+        convert => {
+          "updated_at" => "string"
+        }
+        on_error => "alert_rule_updated_at_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "alert_rule_updated_at_label.value" => "%{updated_at}"
+        }
+        on_error => "alert_rule_updated_at_not_found"
+      }
+
+      if ![alert_rule_updated_at_not_found] and
+        [alert_rule_updated_at_label][value] != "" {
+        mutate {
+          replace => {
+            "alert_rule_updated_at_label.key" => "alert_rule_updated_at"
+          }
+        }
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" =>
+            "alert_rule_updated_at_label"
+          }
+          remove_field => ["alert_rule_updated_at_label"]
+        }
+      }
+    }
+
+    grok {
+      match => {
+        "alert.rule" => [
+          '%{GREEDYDATA:_}classtype:%{DATA:rule_classtype};'
+        ]
+      }
+      on_error => "alert_rule_classtype_not_found"
+      overwrite => ["_"]
+    }
+
+    grok {
+      match => {
+        "alert.rule" => [
+          '%{GREEDYDATA:_}reference:url,%{DATA:reference_url};'
+        ]
+      }
+      on_error => "alert_rule_reference_url_not_found"
+      overwrite => ["_"]
+    }
+
+    mutate {
+      convert => {
+        "rule_content" => "string"
+      }
+      on_error => "alert_rule_content_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "alert_rule_content_label.value" => "%{rule_content}"
+      }
+      on_error => "alert_rule_content_not_found"
+    }
+
+    if ![alert_rule_content_not_found] and
+      [alert_rule_content_label][value] != "" {
+      mutate {
+        replace => {
+          "alert_rule_content_label.key" => "alert_rule_content"
+        }
+      }
+      mutate {
+        merge => {
+          "token_security_result.detection_fields" => "alert_rule_content_label"
+        }
+        remove_field => ["alert_rule_content_label"]
+      }
+    }
+
+    mutate {
+      convert => {
+        "rule_classtype" => "string"
+      }
+      on_error => "alert_rule_classtype_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "alert_rule_classtype_label.value" => "%{rule_classtype}"
+      }
+      on_error => "alert_rule_classtype_not_found"
+    }
+
+    if ![alert_rule_classtype_not_found] and
+      [alert_rule_classtype_label][value] != "" {
+      mutate {
+        replace => {
+          "alert_rule_classtype_label.key" => "alert_rule_classtype"
+        }
+      }
+      mutate {
+        merge => {
+          "token_security_result.detection_fields" =>
+          "alert_rule_classtype_label"
+        }
+        remove_field => ["alert_rule_classtype_label"]
+      }
+    }
+
+    mutate {
+      convert => {
+        "reference_url" => "string"
+      }
+      on_error => "alert_rule_reference_url_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "alert_rule_reference_url_label.value" => "%{reference_url}"
+      }
+      on_error => "alert_rule_reference_url_not_found"
+    }
+
+    if ![alert_rule_reference_url_not_found] and
+      [alert_rule_reference_url_label][value] != "" {
+      mutate {
+        replace => {
+          "alert_rule_reference_url_label.key" => "alert_rule_reference_url"
+        }
+      }
+      mutate {
+        merge => {
+          "token_security_result.detection_fields" =>
+          "alert_rule_reference_url_label"
+        }
+        remove_field => ["alert_rule_reference_url_label"]
+      }
+    }
+
+    for temp_reference in alert.references {
+      mutate {
+        convert => {
+          "temp_reference" => "string"
+        }
+        on_error => "_"
+      }
+
+      mutate {
+        replace => {
+          "token_alert_ref.value" => "%{temp_reference}"
+        }
+        on_error => "alert_reference_not_set"
+      }
+
+      if ![alert_reference_not_set] and [token_alert_ref][value] != "" {
+        mutate {
+          replace => {
+            "token_alert_ref.key" => "alert_references"
+          }
+        }
+
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" => "token_alert_ref"
+          }
+          remove_field => ["token_alert_ref"]
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "payload_printable" => "string"
+      }
+      on_error => "_"
+    }
+
+    mutate {
+      replace => {
+        "token_payload_printable.value" => "%{payload_printable}"
+      }
+      on_error => "payload_printable_not_set"
+    }
+
+    if ![payload_printable_not_set] and [token_payload_printable][value] != "" {
+      mutate {
+        replace => {
+          "token_payload_printable.key" => "payload_printable"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_security_result.detection_fields" => "token_payload_printable"
+        }
+        remove_field => ["token_payload_printable"]
+      }
+    }
+
+    for reference in references {
+      mutate {
+        convert => {
+          "reference" => "string"
+        }
+        on_error => "_"
+      }
+
+      mutate {
+        replace => {
+          "token_ref.value" => "%{reference}"
+        }
+        on_error => "reference_not_set"
+      }
+
+      if ![reference_not_set] and [token_ref][value] != "" {
+        mutate {
+          replace => {
+            "token_ref.key" => "references"
+          }
+        }
+
+        mutate {
+          merge => {
+            "token_security_result.detection_fields" => "token_ref"
+          }
+          remove_field => ["token_ref"]
         }
       }
     }
@@ -9556,9 +11199,64 @@ filter {
 
     mutate {
       replace => {
-        "orig_vulnerabiliti_details.cve_description" => "%{orig_vulnerable_host.source}"
+        "orig_vulnerabiliti_details.cve_description" =>
+        "%{orig_vulnerable_host.source}"
       }
       on_error => "orig_vulnerable_host_source_not_found"
+    }
+
+    mutate {
+      replace => {
+        "_" => "%{orig_vulnerable_host.criticality}"
+      }
+      on_error => "orig_vulnerable_host_criticality_not_found"
+    }
+
+    if ![orig_vulnerable_host_criticality_not_found] {
+      if [orig_vulnerable_host][criticality] =~ "(?i)Critical"
+      or [orig_vulnerable_host][criticality] == "4" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "CRITICAL"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)High"
+      or [orig_vulnerable_host][criticality] == "3" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "HIGH"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Low"
+      or [orig_vulnerable_host][criticality] == "1" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "LOW"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Medium"
+      or [orig_vulnerable_host][criticality] == "2" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" => "MEDIUM"
+          }
+        }
+      }else if [orig_vulnerable_host][criticality] =~ "(?i)Unknown_Severity"
+      or [orig_vulnerable_host][criticality] == "0" {
+        mutate {
+          replace => {
+            "orig_vulnerabiliti_details.severity" =>
+            "UNKNOWN_SEVERITY"
+          }
+        }
+      }
+
+      mutate {
+        replace => {
+          "orig_vulnerabiliti_details.severity_details" =>
+          "%{orig_vulnerable_host.criticality}"
+        }
+      }
     }
 
     mutate {
@@ -9577,14 +11275,16 @@ filter {
 
     mutate {
       replace => {
-        "token_principal.asset.network_domain" => "%{orig_vulnerable_host.machine_domain}"
+        "token_principal.asset.network_domain" =>
+        "%{orig_vulnerable_host.machine_domain}"
       }
       on_error => "orig_vulnerable_host_machine_domain_not_found"
     }
 
     mutate {
       replace => {
-        "token_principal.asset.platform_software.platform_version" => "%{orig_vulnerable_host.os_version}"
+        "token_principal.asset.platform_software.platform_version" =>
+        "%{orig_vulnerable_host.os_version}"
       }
       on_error => "orig_vulnerable_host_os_version_not_found"
     }
@@ -9610,9 +11310,64 @@ filter {
 
     mutate {
       replace => {
-        "resp_vulnerabiliti_details.cve_description" => "%{resp_vulnerable_host.source}"
+        "resp_vulnerabiliti_details.cve_description" =>
+        "%{resp_vulnerable_host.source}"
       }
       on_error => "resp_vulnerable_host_source_not_found"
+    }
+
+    mutate {
+      replace => {
+        "_" => "%{resp_vulnerable_host.criticality}"
+      }
+      on_error => "resp_vulnerable_host_criticality_not_found"
+    }
+
+    if ![resp_vulnerable_host_criticality_not_found] {
+      if [resp_vulnerable_host][criticality] =~ "(?i)Critical"
+      or [resp_vulnerable_host][criticality] == "4" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "CRITICAL"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)High"
+      or [resp_vulnerable_host][criticality] == "3" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "HIGH"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Low"
+      or [resp_vulnerable_host][criticality] == "1" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "LOW"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Medium"
+      or [resp_vulnerable_host][criticality] == "2" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" => "MEDIUM"
+          }
+        }
+      }else if [resp_vulnerable_host][criticality] =~ "(?i)Unknown_Severity"
+      or [resp_vulnerable_host][criticality] == "0" {
+        mutate {
+          replace => {
+            "resp_vulnerabiliti_details.severity" =>
+            "UNKNOWN_SEVERITY"
+          }
+        }
+      }
+
+      mutate {
+        replace => {
+          "resp_vulnerabiliti_details.severity_details" =>
+          "%{resp_vulnerable_host.criticality}"
+        }
+      }
     }
 
     mutate {
@@ -9631,19 +11386,67 @@ filter {
 
     mutate {
       replace => {
-        "token_target.asset.network_domain" => "%{resp_vulnerable_host.machine_domain}"
+        "token_target.asset.network_domain" =>
+        "%{resp_vulnerable_host.machine_domain}"
       }
       on_error => "resp_vulnerable_host_machine_domain_not_found"
     }
 
     mutate {
       replace => {
-        "token_target.asset.platform_software.platform_version" => "%{resp_vulnerable_host.os_version}"
+        "token_target.asset.platform_software.platform_version" =>
+        "%{resp_vulnerable_host.os_version}"
       }
       on_error => "resp_vulnerable_host_os_version_not_found"
     }
 
-    # check if required udm validation fields for SCAN_NETWORK exist.
+    # UDM > additional
+    for mt in meta {
+      mutate {
+        convert => {
+          "mt" => "string"
+        }
+        on_error => "failed_to_convert_mt_to_string"
+      }
+
+      mutate {
+        replace => {
+          "meta_value.string_value" => "%{mt}"
+        }
+      }
+
+      mutate {
+        merge => {
+          "meta_label.value.list_value.values" => "meta_value"
+        }
+        on_error => "failed_to_merge_meta_label"
+        remove_field => ["meta_value"]
+      }
+    }
+
+    mutate {
+      merge => {
+        "temp_arr" => "meta_label"
+      }
+      on_error => "meta_label_not_exist"
+    }
+
+    if ![meta_label_not_exist] {
+      mutate {
+        replace => {
+          "meta_label.key" => "meta"
+        }
+      }
+
+      mutate {
+        merge => {
+          "token_additional.fields" => "meta_label"
+        }
+        remove_field => ["meta_label"]
+      }
+    }
+
+    # Check if required udm validation fields for SCAN_NETWORK exist.
     if [principal_present] == "true" {
       mutate {
         replace => {
@@ -9676,7 +11479,8 @@ filter {
           }
         }
       }
-      else if [indicator_type] in ["Intel::SOFTWARE", "Intel::CERT_HASH", "Intel::PUBKEY_HASH"] {
+      else if [indicator_type] in ["Intel::SOFTWARE", "Intel::CERT_HASH",
+      "Intel::PUBKEY_HASH"] {
         mutate {
           replace => {
             "entity_metadata.entity_type" => "RESOURCE"
@@ -10605,7 +12409,377 @@ filter {
       }
     }
 
-    # check if required udm validation fields for SCAN_NETWORK exist.
+    mutate {
+      convert => {
+        "id.vlan" => "string"
+      }
+      on_error => "id_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_vlan_label.value.string_value" => "%{id.vlan}"
+      }
+      on_error => "id_vlan_not_found"
+    }
+
+    if ![id_vlan_not_found] and
+      [id_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_vlan_label.key" => "id_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.vlan_inner" => "string"
+      }
+      on_error => "id_vlan_inner_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_vlan_inner_label.value.string_value" => "%{id.vlan_inner}"
+      }
+      on_error => "id_vlan_inner_not_found"
+    }
+
+    if ![id_vlan_inner_not_found] and
+      [id_vlan_inner_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_vlan_inner_label.key" => "id_vlan_inner"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_vlan_inner_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_cid" => "string"
+      }
+      on_error => "id_orig_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_cid_label.value.string_value" => "%{id.orig_ep_cid}"
+      }
+      on_error => "id_orig_ep_cid_not_found"
+    }
+
+    if ![id_orig_ep_cid_not_found] and
+      [id_orig_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_cid_label.key" => "id_orig_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_source" => "string"
+      }
+      on_error => "id_orig_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_source_label.value.string_value" =>
+        "%{id.orig_ep_source}"
+      }
+      on_error => "id_orig_ep_source_not_found"
+    }
+
+    if ![id_orig_ep_source_not_found] and
+      [id_orig_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_source_label.key" => "id_orig_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_status" => "string"
+      }
+      on_error => "id_orig_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_status_label.value.string_value" =>
+        "%{id.orig_ep_status}"
+      }
+      on_error => "id_orig_ep_status_not_found"
+    }
+
+    if ![id_orig_ep_status_not_found] and
+      [id_orig_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_status_label.key" => "id_orig_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.orig_ep_uid" => "string"
+      }
+      on_error => "id_orig_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_orig_ep_uid_label.value.string_value" => "%{id.orig_ep_uid}"
+      }
+      on_error => "id_orig_ep_uid_not_found"
+    }
+
+    if ![id_orig_ep_uid_not_found] and
+      [id_orig_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_orig_ep_uid_label.key" => "id_orig_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_orig_ep_uid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_cid" => "string"
+      }
+      on_error => "id_resp_ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_cid_label.value.string_value" => "%{id.resp_ep_cid}"
+      }
+      on_error => "id_resp_ep_cid_not_found"
+    }
+
+    if ![id_resp_ep_cid_not_found] and
+      [id_resp_ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_cid_label.key" => "id_resp_ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_source" => "string"
+      }
+      on_error => "id_resp_ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_source_label.value.string_value" =>
+        "%{id.resp_ep_source}"
+      }
+      on_error => "id_resp_ep_source_not_found"
+    }
+
+    if ![id_resp_ep_source_not_found] and
+      [id_resp_ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_source_label.key" => "id_resp_ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_status" => "string"
+      }
+      on_error => "id_resp_ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_status_label.value.string_value" =>
+        "%{id.resp_ep_status}"
+      }
+      on_error => "id_resp_ep_status_not_found"
+    }
+
+    if ![id_resp_ep_status_not_found] and
+      [id_resp_ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_status_label.key" => "id_resp_ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "id.resp_ep_uid" => "string"
+      }
+      on_error => "id_resp_ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "id_resp_ep_uid_label.value.string_value" => "%{id.resp_ep_uid}"
+      }
+      on_error => "id_resp_ep_uid_not_found"
+    }
+
+    if ![id_resp_ep_uid_not_found] and
+      [id_resp_ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "id_resp_ep_uid_label.key" => "id_resp_ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "id_resp_ep_uid_label"
+        }
+      }
+    }
+
+    # UDM > entity > security_result
+    for score in threat_score {
+      mutate {
+        convert => {
+          "score" => "string"
+        }
+        on_error => "score_conversion_error"
+      }
+
+      mutate {
+        replace => {
+          "threat_score_label.value" => "%{score}"
+        }
+        on_error => "score_not_found"
+      }
+
+      if ![score_not_found] and [score] != "" {
+        mutate {
+          replace => {
+            "threat_score_label.key" => "threat_score"
+          }
+        }
+        mutate {
+          merge => {
+            "threat_score_security_result.detection_fields" =>
+            "threat_score_label"
+          }
+          remove_field => ["threat_score_label"]
+        }
+      }
+    }
+
+    for verd in verdict {
+      if [verd] =~ "(?i)Malicious" or [verd] == "1" {
+        mutate {
+          replace => {
+            "verdict_info.verdict_response" => "MALICIOUS"
+          }
+        }
+      }else if [verd] =~ "(?i)Benign" or [verd] == "2" {
+        mutate {
+          replace => {
+            "verdict_info.verdict_response" => "BENIGN"
+          }
+        }
+      }else {
+        mutate {
+          replace => {
+            "verdict_info.verdict_response" => "VERDICT_RESPONSE_UNSPECIFIED"
+          }
+        }
+      }
+
+      mutate {
+        merge => {
+          "threat_score_security_result.verdict_info" => "verdict_info"
+        }
+        on_error => "verdict_info_not_found"
+        remove_field => ["verdict_info"]
+      }
+    }
+
+    for src in verdict_source {
+      mutate {
+        replace => {
+          "verdict_info.source_provider" => "%{src}"
+        }
+        on_error => "verdict_source_not_found"
+      }
+
+      mutate {
+        merge => {
+          "threat_score_security_result.verdict_info" => "verdict_info"
+        }
+        on_error => "verdict_info_not_found"
+        remove_field => ["verdict_info"]
+      }
+    }
+
+    mutate {
+      merge => {
+        "token_entity.security_result" => "threat_score_security_result"
+      }
+      on_error => "threat_score_security_result_not_found"
+    }
+
+    # Check if required udm validation fields for SCAN_NETWORK exist.
     if [principal_present] == "true" {
       mutate {
         replace => {
@@ -10614,7 +12788,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [indicator_type_not_found] or [required_field_not_found] == "true" or
     [inteval_start_time_not_found] == "true" {
       drop {
@@ -10627,6 +12801,7 @@ filter {
         "token_ioc" => "event1.ioc"
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
 
@@ -10782,7 +12957,148 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # UDM > additional
+    mutate {
+      convert => {
+        "invoke_id" => "string"
+      }
+      on_error => "invoke_id_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "invoke_id_label.value.string_value" => "%{invoke_id}"
+      }
+      on_error => "invoke_id_not_found"
+    }
+
+    if ![invoke_id_not_found] and
+      [invoke_id_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "invoke_id_label.key" => "invoke_id"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "invoke_id_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "is_orig" => "string"
+      }
+      on_error => "is_orig_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "is_orig_label.value.string_value" => "%{is_orig}"
+      }
+      on_error => "is_orig_not_found"
+    }
+
+    if ![is_orig_not_found] and
+      [is_orig_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "is_orig_label.key" => "is_orig"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "is_orig_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "pdu_service" => "string"
+      }
+      on_error => "pdu_service_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "pdu_service_label.value.string_value" => "%{pdu_service}"
+      }
+      on_error => "pdu_service_not_found"
+    }
+
+    if ![pdu_service_not_found] and
+      [pdu_service_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "pdu_service_label.key" => "pdu_service"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "pdu_service_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "pdu_type" => "string"
+      }
+      on_error => "pdu_type_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "pdu_type_label.value.string_value" => "%{pdu_type}"
+      }
+      on_error => "pdu_type_not_found"
+    }
+
+    if ![pdu_type_not_found] and
+      [pdu_type_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "pdu_type_label.key" => "pdu_type"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "pdu_type_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "result_code" => "string"
+      }
+      on_error => "result_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "result_code_label.value.string_value" => "%{result_code}"
+      }
+      on_error => "result_code_not_found"
+    }
+
+    if ![result_code_not_found] and
+      [result_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "result_code_label.key" => "result_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "result_code_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -10875,7 +13191,375 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # UDM > additional
+    mutate {
+      convert => {
+        "attribute_id" => "string"
+      }
+      on_error => "attribute_id_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "attribute_id_label.value.string_value" => "%{attribute_id}"
+      }
+      on_error => "attribute_id_not_found"
+    }
+
+    if ![attribute_id_not_found] and
+      [attribute_id_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "attribute_id_label.key" => "attribute_id"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "attribute_id_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_extended_status" => "string"
+      }
+      on_error => "cip_extended_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_extended_status_label.value.string_value" =>
+        "%{cip_extended_status}"
+      }
+      on_error => "cip_extended_status_not_found"
+    }
+
+    if ![cip_extended_status_not_found] and
+      [cip_extended_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_extended_status_label.key" => "cip_extended_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_extended_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_extended_status_code" => "string"
+      }
+      on_error => "cip_extended_status_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_extended_status_code_label.value.string_value" =>
+        "%{cip_extended_status_code}"
+      }
+      on_error => "cip_extended_status_code_not_found"
+    }
+
+    if ![cip_extended_status_code_not_found] and
+      [cip_extended_status_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_extended_status_code_label.key" => "cip_extended_status_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_extended_status_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_sequence_count" => "string"
+      }
+      on_error => "cip_sequence_count_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_sequence_count_label.value.string_value" =>
+        "%{cip_sequence_count}"
+      }
+      on_error => "cip_sequence_count_not_found"
+    }
+
+    if ![cip_sequence_count_not_found] and
+      [cip_sequence_count_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_sequence_count_label.key" => "cip_sequence_count"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_sequence_count_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_service" => "string"
+      }
+      on_error => "cip_service_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_service_label.value.string_value" => "%{cip_service}"
+      }
+      on_error => "cip_service_not_found"
+    }
+
+    if ![cip_service_not_found] and
+      [cip_service_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_service_label.key" => "cip_service"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_service_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_service_code" => "string"
+      }
+      on_error => "cip_service_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_service_code_label.value.string_value" => "%{cip_service_code}"
+      }
+      on_error => "cip_service_code_not_found"
+    }
+
+    if ![cip_service_code_not_found] and
+      [cip_service_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_service_code_label.key" => "cip_service_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_service_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_status" => "string"
+      }
+      on_error => "cip_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_status_label.value.string_value" => "%{cip_status}"
+      }
+      on_error => "cip_status_not_found"
+    }
+
+    if ![cip_status_not_found] and
+      [cip_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_status_label.key" => "cip_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "cip_status_code" => "string"
+      }
+      on_error => "cip_status_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "cip_status_code_label.value.string_value" => "%{cip_status_code}"
+      }
+      on_error => "cip_status_code_not_found"
+    }
+
+    if ![cip_status_code_not_found] and
+      [cip_status_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "cip_status_code_label.key" => "cip_status_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "cip_status_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "class_id" => "string"
+      }
+      on_error => "class_id_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "class_id_label.value.string_value" => "%{class_id}"
+      }
+      on_error => "class_id_not_found"
+    }
+
+    if ![class_id_not_found] and
+      [class_id_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "class_id_label.key" => "class_id"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "class_id_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "class_name" => "string"
+      }
+      on_error => "class_name_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "class_name_label.value.string_value" => "%{class_name}"
+      }
+      on_error => "class_name_not_found"
+    }
+
+    if ![class_name_not_found] and
+      [class_name_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "class_name_label.key" => "class_name"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "class_name_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "direction" => "string"
+      }
+      on_error => "direction_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "direction_label.value.string_value" => "%{direction}"
+      }
+      on_error => "direction_not_found"
+    }
+
+    if ![direction_not_found] and
+      [direction_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "direction_label.key" => "direction"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "direction_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "instance_id" => "string"
+      }
+      on_error => "instance_id_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "instance_id_label.value.string_value" => "%{instance_id}"
+      }
+      on_error => "instance_id_not_found"
+    }
+
+    if ![instance_id_not_found] and
+      [instance_id_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "instance_id_label.key" => "instance_id"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "instance_id_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "is_orig" => "string"
+      }
+      on_error => "is_orig_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "is_orig_label.value.string_value" => "%{is_orig}"
+      }
+      on_error => "is_orig_not_found"
+    }
+
+    if ![is_orig_not_found] and
+      [is_orig_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "is_orig_label.key" => "is_orig"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "is_orig_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -10907,7 +13591,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -11027,7 +13712,7 @@ filter {
       on_error => "id_orig_h_not_found"
     }
 
-    # check if required udm validation fields for SCAN_NETWORK exist.
+    # Check if required udm validation fields for SCAN_NETWORK exist.
     if [principal_present] == "true" {
       mutate {
         replace => {
@@ -11115,14 +13800,15 @@ filter {
       }
       mutate {
         merge => {
-          "capture_loss_security_result.detection_fields" => "percent_lost_labels"
+          "capture_loss_security_result.detection_fields" =>
+          "percent_lost_labels"
         }
       }
     }
 
     mutate {
       replace => {
-        "token_metadata.description" => 
+        "token_metadata.description" =>
         "node %{_system_name} experienced %{percent_lost}% packet loss at %{ts}."
       }
       on_error => "failed_to_set_description"
@@ -11239,7 +13925,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for SCAN_NETWORK exist.
+    # Check if required udm validation fields for SCAN_NETWORK exist.
     if [principal_present] == "true" {
       mutate {
         replace => {
@@ -11733,7 +14419,12 @@ filter {
   # ----------------------------------------------------------------------
   # DHCP
   else if [_path] == "dhcp" {
-
+    mutate {
+      replace => {
+        "is_dhcp_ciaddr_exist" => "false"
+        "is_dhcp_yiaddr_exist" => "false"
+      }
+    }
     # UDM > Network
     mutate {
       replace => {
@@ -11757,11 +14448,17 @@ filter {
     if ![client_addr_not_found] {
       mutate {
         replace => {
+          "is_dhcp_ciaddr_exist" => "true"
+        }
+      }
+
+      mutate {
+        replace => {
           "token_network.dhcp.ciaddr" => "%{client_addr}"
         }
       }
 
-      # Duplicating the client_addr info into ip to skip the validation for NETWORK_DHCP. 
+      # Duplicating the client_addr info into ip to skip the validation for NETWORK_DHCP.
       mutate {
         merge => {
           "token_principal.ip" => "client_addr"
@@ -11848,6 +14545,12 @@ filter {
       on_error => "assigned_addr_not_found"
     }
     if ![assigned_addr_not_found] {
+      mutate {
+        replace => {
+          "is_dhcp_yiaddr_exist" => "true"
+        }
+      }
+
       mutate {
         replace => {
           "token_network.dhcp.yiaddr" => "%{assigned_addr}"
@@ -12025,8 +14728,10 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_DHCP exist, if not set as STATUS_UPDATE.
-    if [principal_present] == "true" and [network_dhcp_present] == "true" {
+    # Check if required udm validation fields for NETWORK_DHCP exist, if not set as STATUS_UPDATE.
+    if [principal_present] == "true" and [network_dhcp_present] == "true"
+    and [is_dhcp_ciaddr_exist] == "true"
+    and [is_dhcp_yiaddr_exist] == "true" {
       mutate {
         replace => {
           "token_metadata.event_type" => "NETWORK_DHCP"
@@ -12187,7 +14892,7 @@ filter {
       on_error => "failed_to_merge_security_result"
     }
 
-    # check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
+    # Check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
     if [principal_present] == "true" and ![query_not_found] {
       mutate {
         replace => {
@@ -12294,7 +14999,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -12325,7 +15030,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -12394,7 +15100,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -12651,7 +15357,121 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # UDM > additional
+    mutate {
+      convert => {
+        "enip_command" => "string"
+      }
+      on_error => "enip_command_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "enip_command_label.value.string_value" => "%{enip_command}"
+      }
+      on_error => "enip_command_not_found"
+    }
+
+    if ![enip_command_not_found] and
+      [enip_command_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "enip_command_label.key" => "enip_command"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "enip_command_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "enip_command_code" => "string"
+      }
+      on_error => "enip_command_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "enip_command_code_label.value.string_value" =>
+        "%{enip_command_code}"
+      }
+      on_error => "enip_command_code_not_found"
+    }
+
+    if ![enip_command_code_not_found] and
+      [enip_command_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "enip_command_code_label.key" => "enip_command_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "enip_command_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "enip_status" => "string"
+      }
+      on_error => "enip_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "enip_status_label.value.string_value" => "%{enip_status}"
+      }
+      on_error => "enip_status_not_found"
+    }
+
+    if ![enip_status_not_found] and
+      [enip_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "enip_status_label.key" => "enip_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "enip_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "is_orig" => "string"
+      }
+      on_error => "is_orig_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "is_orig_label.value.string_value" => "%{is_orig}"
+      }
+      on_error => "is_orig_not_found"
+    }
+
+    if ![is_orig_not_found] and
+      [is_orig_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "is_orig_label.key" => "is_orig"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "is_orig_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -12705,7 +15525,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for STATUS_UPDATE exist.
+    # Check if required udm validation fields for STATUS_UPDATE exist.
     if [principal_present] == "true" {
       mutate {
         replace => {
@@ -12917,7 +15737,7 @@ filter {
       on_error => "failed_to_merge_token_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -13576,7 +16396,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_FTP exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_FTP exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and  [target_present] == "true" {
       mutate {
         replace => {
@@ -13706,7 +16526,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_DNS exist.
+    # Check if required udm validation fields for NETWORK_DNS exist.
     if [principal_present] == "true" and ![questions_not_found] {
       mutate {
         replace => {
@@ -13792,7 +16612,7 @@ filter {
       }
       mutate {
         merge => {
-          "generic_icmp_tunnels_security_result.detection_fields" => 
+          "generic_icmp_tunnels_security_result.detection_fields" =>
           "detection_labels"
         }
       }
@@ -13943,7 +16763,7 @@ filter {
       on_error => "failed_to_merge_security_result"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -14117,7 +16937,7 @@ filter {
       on_error => "failed_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -14771,7 +17591,36 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # UDM > additional
+    mutate {
+      convert => {
+        "is_orig" => "string"
+      }
+      on_error => "is_orig_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "is_orig_label.value.string_value" => "%{is_orig}"
+      }
+      on_error => "is_orig_not_found"
+    }
+
+    if ![is_orig_not_found] and
+      [is_orig_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "is_orig_label.key" => "is_orig"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "is_orig_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -14804,7 +17653,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -14888,7 +17738,7 @@ filter {
       on_error => "failed_to_merge_security_result"
     }
 
-    # check if required udm validation fields for STATUS_UPDATE exist.
+    # Check if required udm validation fields for STATUS_UPDATE exist.
     if [principal_present] == "true" {
       # Duplicating the ip info into host name to skip the validation while using the udm2sdm flag:
       # *events_go_proto.Event_Edr: client device for EDR network event must have more than IP addresses filled
@@ -14933,7 +17783,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -15014,7 +17864,7 @@ filter {
       on_error => "failed_to_merge_about"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE.
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -15060,7 +17910,7 @@ filter {
       }
     }
 
-    # drop stats and poststats, no security value -  low level packet capture stat logs
+    # Drop stats and poststats, no security value -  low level packet capture stat logs
     if [event_type] =~ "stats" {
       drop {
         tag => "TAG_NO_SECURITY_VALUE"
@@ -15160,7 +18010,8 @@ filter {
         else {
           mutate {
             replace => {
-              "token_target.url" => "http://%{http.hostname}:%{dest_port_str}%{http.url}"
+              "token_target.url" =>
+              "http://%{http.hostname}:%{dest_port_str}%{http.url}"
             }
             on_error => "url_not_found"
           }
@@ -15175,17 +18026,17 @@ filter {
         on_error => "url_not_found"
       }
     }
-    # end http
+    # End http
 
     ################################
-    # event_type 'dns' specific
+    # Event_type 'dns' specific
     ################################
     #
-    # only support for single dns suricata data, not grouped/detailed
+    # Only support for single dns suricata data, not grouped/detailed
     # grouped/detailed does work with this config, but the additional data is not parsed into the UDM
-    # only 9 most common dns record types supported
-    # only 9 most common dns response codes supported
-    # full list here http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+    # Only 9 most common dns record types supported
+    # Only 9 most common dns response codes supported
+    # Full list here http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
 
     if [event_type] == "dns" {
       mutate {
@@ -15585,7 +18436,7 @@ filter {
             }
             on_error => "rrtype_not_found"
           }
-          # dns ttl isn't always present
+          # Dns ttl isn't always present
           mutate {
             replace => {
               "dns_answers.resourcerecord.ttl" => "%{dns.ttl}"
@@ -15676,7 +18527,7 @@ filter {
     }
 
     ################################
-    # event_type 'alert' specific
+    # Event_type 'alert' specific
     ################################
     if [event_type] == "alert" {
 
@@ -15720,21 +18571,26 @@ filter {
         on_error => "category_not_found"
       }
       if ![category_not_found] {
-        if [alert][category] in ["Misc Attack", "Device Retrieving External IP Address Detected", "Potentially Bad Traffic", "Targeted Malicious Activity was Detected", "A suspicious string was detected"] {
+        if [alert][category] in ["Misc Attack",
+        "Device Retrieving External IP Address Detected",
+        "Potentially Bad Traffic", "Targeted Malicious Activity was Detected",
+        "A suspicious string was detected"] {
           mutate {
             replace => {
               "sr_category" => "NETWORK_MALICIOUS"
             }
           }
         }
-        else if [alert][category] in ["Not Suspicious Traffic","Misc activity","Unknown Traffic"] {
+        else if [alert][category] in ["Not Suspicious Traffic",
+        "Misc activity","Unknown Traffic"] {
           mutate {
             replace => {
               "sr_category" => "NETWORK_SUSPICIOUS"
             }
           }
         }
-        else if [alert][category] in ["Attempted User Privilege Gain", "Attempted Administrator Privilege Gain", "Web Application Attack"] {
+        else if [alert][category] in ["Attempted User Privilege Gain",
+        "Attempted Administrator Privilege Gain", "Web Application Attack"] {
           mutate {
             replace => {
               "sr_category" => "EXPLOIT"
@@ -15762,7 +18618,9 @@ filter {
             }
           }
         }
-        else if [alert][category] in ["access to a potentially vulnerable web application", "Detection of a Network Scan"] {
+        else if [alert][category] in
+        ["access to a potentially vulnerable web application",
+        "Detection of a Network Scan"] {
           mutate {
             replace => {
               "sr_category" => "NETWORK_RECON"
@@ -15801,34 +18659,33 @@ filter {
         if [alert][severity] == "1" {
           mutate {
             replace => {
-              "eve_security_result.priority" => "HIGH_PRIORITY"
+              "eve_security_result.priority" => "PRIORITY_CRITICAL"
+              "eve_security_result.severity" => "CRITICAL"
             }
           }
         }
         else if [alert][severity] == "2" {
           mutate {
             replace => {
-              "eve_security_result.priority" => "MEDIUM_PRIORITY"
+              "eve_security_result.priority" => "HIGH_PRIORITY"
+              "eve_security_result.severity" => "HIGH"
             }
           }
         }
         else if [alert][severity] == "3" {
           mutate {
             replace => {
-              "eve_security_result.priority" => "LOW_PRIORITY"
+              "eve_security_result.priority" => "MEDIUM_PRIORITY"
+              "eve_security_result.severity" => "MEDIUM"
             }
           }
         }
-        else {
+        else if [alert][severity] == "4" {
           mutate {
             replace => {
-              "eve_security_result.priority" => "UNKNOWN_PRIORITY"
+              "eve_security_result.priority" => "LOW_PRIORITY"
+              "eve_security_result.severity" => "LOW"
             }
-          }
-        }
-        mutate {
-          replace => {
-            "eve_security_result.severity" => "INFORMATIONAL"
           }
         }
         mutate {
@@ -15887,7 +18744,7 @@ filter {
         on_error => "failed_to_merge"
       }
 
-      # tuning ACE
+      # Tuning ACE
       mutate {
         replace => {
           "payload_labels.value" => "%{payload}"
@@ -16093,11 +18950,13 @@ filter {
       }
       mutate {
         replace => {
-          "affected_product_label.value" => "%{alert.metadata.affected_product.0}"
+          "affected_product_label.value" =>
+          "%{alert.metadata.affected_product.0}"
         }
         on_error => "no_affected_product_label"
       }
-      if ![no_affected_product_label] and [alert][metadata][affected_product][0] != "" {
+      if ![no_affected_product_label]
+      and [alert][metadata][affected_product][0] != "" {
         mutate {
           replace => {
             "affected_product_label.key" => "affected_product"
@@ -16123,7 +18982,8 @@ filter {
         }
         on_error => "no_attack_target_label"
       }
-      if ![no_attack_target_label] and [alert][metadata][attack_target][0] != "" {
+      if ![no_attack_target_label]
+      and [alert][metadata][attack_target][0] != "" {
         mutate {
           replace => {
             "attack_target_label.key" => "attack_target"
@@ -16175,7 +19035,8 @@ filter {
         }
         on_error => "no_former_category_label"
       }
-      if ![no_former_category_label] and [alert][metadata][former_category][0] != "" {
+      if ![no_former_category_label]
+      and [alert][metadata][former_category][0] != "" {
         mutate {
           replace => {
             "former_category_label.key" => "former_category"
@@ -16197,11 +19058,13 @@ filter {
       }
       mutate {
         replace => {
-          "signature_severity_label.value" => "%{alert.metadata.signature_severity.0}"
+          "signature_severity_label.value" =>
+          "%{alert.metadata.signature_severity.0}"
         }
         on_error => "no_signature_severity_label"
       }
-      if ![no_signature_severity_label] and [alert][metadata][signature_severity][0] != "" {
+      if ![no_signature_severity_label]
+      and [alert][metadata][signature_severity][0] != "" {
         mutate {
           replace => {
             "signature_severity_label.key" => "signature_severity"
@@ -16264,10 +19127,10 @@ filter {
         }
       }
     }
-    # end alert
+    # End alert
 
     ################################
-    # event_type 'dhcp' specific
+    # Event_type 'dhcp' specific
     ################################
     #
     if [event_type] == "dhcp" {
@@ -16303,7 +19166,7 @@ filter {
           }
         }
       }
-      # opCode proto only supports these two options
+      # OpCode proto only supports these two options
       mutate {
         replace => {
           "dhcp.type" => "%{dhcp.type}"
@@ -16401,10 +19264,10 @@ filter {
         }
       }
     }
-    # end dhcp
+    # End dhcp
 
     ################################
-    # event_type 'tls' specific
+    # Event_type 'tls' specific
     ################################
     #
     if [event_type] == "tls" {
@@ -16444,10 +19307,10 @@ filter {
       }
 
     }
-    # end tls
+    # End tls
 
     ################################
-    # event_type 'flow' specific
+    # Event_type 'flow' specific
     ################################
 
     if [event_type] == "flow" {
@@ -16487,7 +19350,7 @@ filter {
       }
 
     }
-    # end flow
+    # End flow
 
     if [event_type] == "rdp" {
 
@@ -16627,6 +19490,48 @@ filter {
       }
     }
 
+    mutate {
+      replace => {
+        "token_payload_printable.value" => "%{payload_printable}"
+      }
+      on_error => "payload_not_found"
+    }
+
+    if ![payload_not_found] and [payload_printable] != "" {
+      mutate {
+        replace => {
+          "token_payload_printable.key" => "payload_printable"
+        }
+      }
+
+      mutate {
+        merge => {
+          "eve_security_result.detection_fields" => "token_payload_printable"
+        }
+      }
+    }
+
+    mutate {
+      replace => {
+        "token_rule.value" => "%{alert.rule}"
+      }
+      on_error => "rule_not_found"
+    }
+
+    if ![rule_not_found] and [alert][rule] != "" {
+      mutate {
+        replace => {
+          "token_rule.key" => "rule"
+        }
+      }
+
+      mutate {
+        merge => {
+          "eve_security_result.detection_fields" => "token_rule"
+        }
+      }
+    }
+
     #################################
     # General
     #################################
@@ -16636,7 +19541,7 @@ filter {
       on_error => "failed_parse_date"
     }
 
-    ### udm > principal
+    # UDM > Principal
     grok {
       match => {
         "src_ip" => "%{IP:src_ip}"
@@ -16673,7 +19578,7 @@ filter {
     }
 
 
-    ### udm > target
+    # UDM > Target
     grok {
       match => {
         "dest_ip" => "%{IP:dest_ip}"
@@ -16708,7 +19613,7 @@ filter {
       }
       on_error => "rename_error"
     }
-    ### udm > network
+    # UDM > Network
 
     mutate {
       convert => {
@@ -16734,7 +19639,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -16780,14 +19686,14 @@ filter {
       else {
         mutate {
           replace => {
-            "token_network.application_protocol" => 
+            "token_network.application_protocol" =>
             "UNKNOWN_APPLICATION_PROTOCOL"
           }
         }
       }
     }
 
-    # udm > observer
+    # UDM > Observer
 
     mutate {
       replace => {
@@ -16810,7 +19716,8 @@ filter {
       on_error => "failed_to_merge_intermediary"
     }
 
-    if [token_metadata][event_type] in ["NETWORK_CONNECTION", "NETWORK_HTTP", "NETWORK_FLOW"] {
+    if [token_metadata][event_type] in ["NETWORK_CONNECTION", "NETWORK_HTTP",
+    "NETWORK_FLOW"] {
       if [principal_present] == "false" or [target_present] == "false" {
         mutate {
           replace => {
@@ -16896,7 +19803,7 @@ filter {
       on_error => "iso_cotp_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -17205,7 +20112,7 @@ filter {
       on_error => "kerberos_security_result_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -17428,7 +20335,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -17720,7 +20627,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -18041,6 +20948,62 @@ filter {
         "token_about" => "local_subnets_dj_about"
       }
       on_error => "local_subnets_dj_about_not_found"
+    }
+
+    # UDM > additional
+    mutate {
+      convert => {
+        "component_id" => "string"
+      }
+      on_error => "component_id_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "component_id_label.value.string_value" => "%{component_id}"
+      }
+      on_error => "component_id_not_found"
+    }
+
+    if ![component_id_not_found] and
+      [component_id_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "component_id_label.key" => "component_id"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "component_id_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "round" => "string"
+      }
+      on_error => "round_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "round_label.value.string_value" => "%{round}"
+      }
+      on_error => "round_not_found"
+    }
+
+    if ![round_not_found] and [round_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "round_label.key" => "round"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "round_label"
+        }
+      }
     }
   }
 
@@ -18408,7 +21371,90 @@ filter {
       on_error => "modbus_security_result_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # UDM > additional
+    mutate {
+      convert => {
+        "pdu_type" => "string"
+      }
+      on_error => "pdu_type_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "pdu_type_label.value.string_value" => "%{pdu_type}"
+      }
+      on_error => "pdu_type_not_found"
+    }
+
+    if ![pdu_type_not_found] and
+      [pdu_type_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "pdu_type_label.key" => "pdu_type"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "pdu_type_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "tid" => "string"
+      }
+      on_error => "tid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "tid_label.value.string_value" => "%{tid}"
+      }
+      on_error => "tid_not_found"
+    }
+
+    if ![tid_not_found] and [tid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "tid_label.key" => "tid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "tid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "unit" => "string"
+      }
+      on_error => "unit_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "unit_label.value.string_value" => "%{unit}"
+      }
+      on_error => "unit_not_found"
+    }
+
+    if ![unit_not_found] and [unit_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "unit_label.key" => "unit"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "unit_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -18551,7 +21597,7 @@ filter {
       on_error => "mqtt_connect_security_result_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -18744,7 +21790,7 @@ filter {
       on_error => "mqtt_publish_security_result_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -18913,7 +21959,7 @@ filter {
       on_error => "mqtt_subscribe_security_result_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -19037,6 +22083,37 @@ filter {
     }
 
     mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_certs_security_result.detection_fields" => "long_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
       merge => {
         "token_security_result" => "known_certs_security_result"
       }
@@ -19075,6 +22152,19 @@ filter {
     mutate {
       rename => {
         "port" => "token_entity.port"
+      }
+    }
+
+    mutate {
+      convert => {
+        "port_num" => "integer"
+      }
+      on_error => "port_num_conversion_failed"
+    }
+
+    mutate {
+      rename => {
+        "port_num" => "token_entity.port"
       }
     }
 
@@ -19269,7 +22359,64 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > entity > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or
     [interval_start_time_not_found] == "true" {
       drop {
@@ -19281,6 +22428,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -19381,6 +22529,38 @@ filter {
       mutate {
         merge => {
           "known_devices_security_result.detection_fields" => "num_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_devices_security_result.detection_fields" =>
+          "long_conns_labels"
         }
       }
       mutate {
@@ -19572,7 +22752,64 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > entity > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or
     [interval_start_time_not_found] == "true" {
       drop {
@@ -19584,6 +22821,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -19685,6 +22923,38 @@ filter {
       mutate {
         merge => {
           "known_domains_security_result.detection_fields" => "num_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_domains_security_result.detection_fields" =>
+          "long_conns_labels"
         }
       }
       mutate {
@@ -19867,7 +23137,64 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > entity > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or [interval_start_time_not_found] == "true"
     or [required_not_found] == "true" {
       drop {
@@ -19879,6 +23206,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -19918,6 +23246,13 @@ filter {
           "interval_start_time_not_found" => "false"
         }
       }
+    }
+
+    mutate {
+      replace => {
+        "entity_metadata.description" => "%{ep.desc}"
+      }
+      on_error => "ep_desc_not_found"
     }
 
     mutate {
@@ -20210,7 +23545,222 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    mutate {
+      replace => {
+        "token_entity.platform_version" => "%{ep.os_version}"
+      }
+      on_error => "ep_os_version_not_found"
+    }
+
+    # UDM > entity > security_result
+    mutate {
+      convert => {
+        "ep.criticality" => "string"
+      }
+      on_error => "ep_criticality_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "ep_criticatility_label.value" => "%{ep.criticality}"
+      }
+      on_error => "ep_criticatility_not_found"
+    }
+
+    if ![ep_criticatility_not_found] and [ep_criticatility_label][value] != "" {
+      mutate {
+        replace => {
+          "ep_criticatility_label.key" => "ep_criticatility"
+        }
+      }
+
+      mutate {
+        merge => {
+          "sresult.detection_fields" => "ep_criticatility_label"
+        }
+        on_error => "failed_to_merge_ep_criticatility_label"
+        remove_field => ["ep_criticatility_label"]
+      }
+    }
+
+    mutate {
+      merge => {
+        "token_entity.security_result" => "sresult"
+      }
+      on_error => "failed_to_merge_security_result"
+      remove_field => ["sresult"]
+    }
+
+    # UDM > additional
+    mutate {
+      convert => {
+        "ep.cid" => "string"
+      }
+      on_error => "ep_cid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "ep_cid_label.value.string_value" => "%{ep.cid}"
+      }
+      on_error => "ep_cid_not_found"
+    }
+
+    if ![ep_cid_not_found] and
+      [ep_cid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "ep_cid_label.key" => "ep_cid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "ep_cid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "ep.source" => "string"
+      }
+      on_error => "ep_source_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "ep_source_label.value.string_value" => "%{ep.source}"
+      }
+      on_error => "ep_source_not_found"
+    }
+
+    if ![ep_source_not_found] and
+      [ep_source_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "ep_source_label.key" => "ep_source"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "ep_source_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "ep.status" => "string"
+      }
+      on_error => "ep_status_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "ep_status_label.value.string_value" => "%{ep.status}"
+      }
+      on_error => "ep_status_not_found"
+    }
+
+    if ![ep_status_not_found] and
+      [ep_status_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "ep_status_label.key" => "ep_status"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "ep_status_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "ep.uid" => "string"
+      }
+      on_error => "ep_uid_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "ep_uid_label.value.string_value" => "%{ep.uid}"
+      }
+      on_error => "ep_uid_not_found"
+    }
+
+    if ![ep_uid_not_found] and
+      [ep_uid_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "ep_uid_label.key" => "ep_uid"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "ep_uid_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or [interval_start_time_not_found] == "true"
     or [required_not_found] == "true" {
       drop {
@@ -20222,6 +23772,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -20322,6 +23873,37 @@ filter {
       mutate {
         merge => {
           "known_names_security_result.detection_fields" => "num_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_names_security_result.detection_fields" => "long_conns_labels"
         }
       }
       mutate {
@@ -20483,7 +24065,64 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > entity > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or
     [interval_start_time_not_found] == "true" {
       drop {
@@ -20495,6 +24134,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -20606,6 +24246,38 @@ filter {
     }
 
     mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_remotes_security_result.detection_fields" =>
+          "long_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
       merge => {
         "token_security_result" => "known_remotes_security_result"
       }
@@ -20684,7 +24356,64 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > entity > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or [interval_start_time_not_found] == "true"
     or [required_not_found] == "true" {
       drop {
@@ -20696,6 +24425,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -20807,6 +24537,38 @@ filter {
     }
 
     mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_services_security_result.detection_fields" =>
+          "long_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
       merge => {
         "token_security_result" => "known_services_security_result"
       }
@@ -20839,6 +24601,19 @@ filter {
     mutate {
       rename => {
         "port" => "token_entity.port"
+      }
+    }
+
+    mutate {
+      convert => {
+        "port_num" => "integer"
+      }
+      on_error => "port_num_conversion_failed"
+    }
+
+    mutate {
+      rename => {
+        "port_num" => "token_entity.port"
       }
     }
 
@@ -21046,7 +24821,132 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    mutate {
+      convert => {
+        "num_conns_complete" => "string"
+      }
+      on_error => "num_conns_complete_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "num_conns_complete_label.value" => "%{num_conns_complete}"
+      }
+      on_error => "num_conns_complete_not_found"
+    }
+
+    if ![num_conns_complete_not_found] and
+      [num_conns_complete_label][value] != "" {
+      mutate {
+        replace => {
+          "num_conns_complete_label.key" => "num_conns_complete"
+        }
+      }
+      mutate {
+        merge => {
+          "sresult.detection_fields" =>
+          "num_conns_complete_label"
+        }
+        remove_field => ["num_conns_complete_label"]
+      }
+    }
+
+    mutate {
+      convert => {
+        "num_conns_pending" => "string"
+      }
+      on_error => "num_conns_pending_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "num_conns_pending_label.value" => "%{num_conns_pending}"
+      }
+      on_error => "num_conns_pending_not_found"
+    }
+
+    if ![num_conns_pending_not_found] and
+      [num_conns_pending_label][value] != "" {
+      mutate {
+        replace => {
+          "num_conns_pending_label.key" => "num_conns_pending"
+        }
+      }
+      mutate {
+        merge => {
+          "sresult.detection_fields" =>
+          "num_conns_pending_label"
+        }
+        remove_field => ["num_conns_pending_label"]
+      }
+    }
+
+    mutate {
+      merge => {
+        "token_entity.security_result" => "sresult"
+      }
+      on_error => "failed_to_merge_security_result"
+      remove_field => ["sresult"]
+    }
+
+    # UDM > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or
     [interval_start_time_not_found] == "true" {
       drop {
@@ -21058,6 +24958,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -21158,6 +25059,37 @@ filter {
       mutate {
         merge => {
           "known_users_security_result.detection_fields" => "num_conns_labels"
+        }
+      }
+      mutate {
+        replace => {
+          "threat_not_found" => "false"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "long_conns" => "string"
+      }
+      on_error => "long_conns_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "long_conns_labels.value" => "%{long_conns}"
+      }
+      on_error => "long_conns_not_found"
+    }
+    if ![long_conns_not_found] and [long_conns] != "" {
+      mutate {
+        replace => {
+          "long_conns_labels.key" => "long_conns"
+        }
+      }
+      mutate {
+        merge => {
+          "known_users_security_result.detection_fields" => "long_conns_labels"
         }
       }
       mutate {
@@ -21327,7 +25259,121 @@ filter {
       }
     }
 
-    # check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
+    # UDM > additional
+    mutate {
+      convert => {
+        "host_inner_vlan" => "string"
+      }
+      on_error => "host_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_inner_vlan_label.value.string_value" => "%{host_inner_vlan}"
+      }
+      on_error => "host_inner_vlan_not_found"
+    }
+
+    if ![host_inner_vlan_not_found] and
+      [host_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_inner_vlan_label.key" => "host_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "host_vlan" => "string"
+      }
+      on_error => "host_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "host_vlan_label.value.string_value" => "%{host_vlan}"
+      }
+      on_error => "host_vlan_not_found"
+    }
+
+    if ![host_vlan_not_found] and
+      [host_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "host_vlan_label.key" => "host_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "host_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "remote_inner_vlan" => "string"
+      }
+      on_error => "remote_inner_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "remote_inner_vlan_label.value.string_value" =>
+        "%{remote_inner_vlan}"
+      }
+      on_error => "remote_inner_vlan_not_found"
+    }
+
+    if ![remote_inner_vlan_not_found] and
+      [remote_inner_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "remote_inner_vlan_label.key" => "remote_inner_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "remote_inner_vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "remote_vlan" => "string"
+      }
+      on_error => "remote_vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "remote_vlan_label.value.string_value" => "%{remote_vlan}"
+      }
+      on_error => "remote_vlan_not_found"
+    }
+
+    if ![remote_vlan_not_found] and
+      [remote_vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "remote_vlan_label.key" => "remote_vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "remote_vlan_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for entity and ioc exist. if required field not exist drop entity and ioc event.
     if [threat_not_found] == "true" or
     [interval_start_time_not_found] == "true" {
       drop {
@@ -21339,6 +25385,7 @@ filter {
       rename => {
         "entity_metadata" => "event1.idm.entity.metadata"
         "token_entity" => "event1.idm.entity.entity"
+        "token_additional" => "event1.idm.entity.additional"
       }
     }
   }
@@ -21464,7 +25511,7 @@ filter {
       on_error => "weird_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -21578,7 +25625,7 @@ filter {
       on_error => "wireguard_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -21987,10 +26034,66 @@ filter {
       }
       on_error => "x509_about_not_found"
     }
+
+    # UDM > additional
+    mutate {
+      convert => {
+        "vlan" => "string"
+      }
+      on_error => "vlan_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "vlan_label.value.string_value" => "%{vlan}"
+      }
+      on_error => "vlan_not_found"
+    }
+
+    if ![vlan_not_found] and [vlan_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "vlan_label.key" => "vlan"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "vlan_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "vlan_inner" => "string"
+      }
+      on_error => "vlan_inner_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "vlan_inner_label.value.string_value" => "%{vlan_inner}"
+      }
+      on_error => "vlan_inner_not_found"
+    }
+
+    if ![vlan_inner_not_found] and
+      [vlan_inner_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "vlan_inner_label.key" => "vlan_inner"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "vlan_inner_label"
+        }
+      }
+    }
   }
 
   # ----------------------------------------------------------------------
-  # mysql
+  # Mysql
 
   else if [_path] == "mysql" {
 
@@ -22128,7 +26231,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # napatech_shunting
+  # Napatech_shunting
 
   else if [_path] == "napatech_shunting" {
 
@@ -22156,7 +26259,8 @@ filter {
       }
       mutate {
         merge => {
-          "napatech_token_security_result.detection_fields" => "shunted_flows_labels"
+          "napatech_token_security_result.detection_fields" =>
+          "shunted_flows_labels"
         }
       }
     }
@@ -22233,8 +26337,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # ntlm
-
+  # Ntlm
 
   else if [_path] == "ntlm" {
 
@@ -22329,7 +26432,8 @@ filter {
       on_error => "username_not_found"
     }
 
-    if ![server_dns_computer_name_not_found] or ![server_nb_computer_name_not_found] or ![username_not_found] {
+    if ![server_dns_computer_name_not_found] or
+    ![server_nb_computer_name_not_found] or ![username_not_found] {
       mutate {
         replace => {
           "target_present" => "true"
@@ -22373,7 +26477,7 @@ filter {
       on_error => "token_about_not_set"
     }
 
-    # check if required udm validation fields for USER_LOGIN exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for USER_LOGIN exist, if not set as STATUS_UPDATE
     if [extension_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -22391,8 +26495,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # ntp
-
+  # Ntp
 
   else if [_path] == "ntp" {
 
@@ -22424,7 +26527,7 @@ filter {
       }
     }
 
-    #UDM > Target
+    # UDM > Target
 
     mutate {
       replace => {
@@ -22727,7 +26830,7 @@ filter {
       on_error => "ntp_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -22745,7 +26848,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # pe
+  # Pe
 
   else if [_path] == "pe" {
 
@@ -23151,7 +27254,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # profinet
+  # Profinet
 
   else if [_path] == "profinet" {
 
@@ -23280,7 +27383,7 @@ filter {
       on_error => "profinet_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -23298,11 +27401,11 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # profinet_dce_rpc
+  # Profinet_dce_rpc
 
   else if [_path] == "profinet_dce_rpc" {
 
-    # UDM > Network 
+    # UDM > Network
 
     mutate {
       replace => {
@@ -23480,7 +27583,7 @@ filter {
       on_error => "profinet_dce_rpc_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -23498,7 +27601,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # profinet_debug
+  # Profinet_debug
 
   else if [_path] == "profinet_debug" {
 
@@ -23537,7 +27640,7 @@ filter {
       on_error => "profinet_debug_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -23555,7 +27658,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # radius
+  # Radius
 
   else if [_path] == "radius" {
 
@@ -23713,7 +27816,7 @@ filter {
       on_error => "radius_about_not_found"
     }
 
-    # check if required udm validation fields for USER_LOGIN exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for USER_LOGIN exist, if not set as STATUS_UPDATE
     if [extension_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -23731,7 +27834,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # reporter
+  # Reporter
 
   else if [_path] == "reporter" {
 
@@ -23747,7 +27850,8 @@ filter {
       uppercase => ["level"]
     }
 
-    if ![level_not_found] and [level] in ["CRITICAL", "ERROR", "HIGH", "INFORMATIONAL", "LOW", "MEDIUM"] {
+    if ![level_not_found] and [level] in ["CRITICAL", "ERROR", "HIGH",
+    "INFORMATIONAL", "LOW", "MEDIUM"] {
       mutate {
         replace => {
           "report_security_result.severity" => "%{level}"
@@ -23801,7 +27905,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # rfb
+  # Rfb
 
   else if [_path] == "rfb" {
 
@@ -24080,7 +28184,7 @@ filter {
     }
 
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -24098,7 +28202,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # s7comm
+  # S7comm
 
   else if [_path] == "s7comm" {
 
@@ -24233,7 +28337,288 @@ filter {
       on_error => "s7comm_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # UDM > additional
+    mutate {
+      convert => {
+        "error_class" => "string"
+      }
+      on_error => "error_class_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "error_class_label.value.string_value" => "%{error_class}"
+      }
+      on_error => "error_class_not_found"
+    }
+
+    if ![error_class_not_found] and
+      [error_class_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "error_class_label.key" => "error_class"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "error_class_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "error_code" => "string"
+      }
+      on_error => "error_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "error_code_label.value.string_value" => "%{error_code}"
+      }
+      on_error => "error_code_not_found"
+    }
+
+    if ![error_code_not_found] and
+      [error_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "error_code_label.key" => "error_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "error_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "function_code" => "string"
+      }
+      on_error => "function_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "function_code_label.value.string_value" => "%{function_code}"
+      }
+      on_error => "function_code_not_found"
+    }
+
+    if ![function_code_not_found] and
+      [function_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "function_code_label.key" => "function_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "function_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "function_name" => "string"
+      }
+      on_error => "function_name_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "function_name_label.value.string_value" => "%{function_name}"
+      }
+      on_error => "function_name_not_found"
+    }
+
+    if ![function_name_not_found] and
+      [function_name_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "function_name_label.key" => "function_name"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "function_name_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "is_orig" => "string"
+      }
+      on_error => "is_orig_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "is_orig_label.value.string_value" => "%{is_orig}"
+      }
+      on_error => "is_orig_not_found"
+    }
+
+    if ![is_orig_not_found] and
+      [is_orig_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "is_orig_label.key" => "is_orig"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "is_orig_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "pdu_reference" => "string"
+      }
+      on_error => "pdu_reference_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "pdu_reference_label.value.string_value" => "%{pdu_reference}"
+      }
+      on_error => "pdu_reference_not_found"
+    }
+
+    if ![pdu_reference_not_found] and
+      [pdu_reference_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "pdu_reference_label.key" => "pdu_reference"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "pdu_reference_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "rosctr_code" => "string"
+      }
+      on_error => "rosctr_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "rosctr_code_label.value.string_value" => "%{rosctr_code}"
+      }
+      on_error => "rosctr_code_not_found"
+    }
+
+    if ![rosctr_code_not_found] and
+      [rosctr_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "rosctr_code_label.key" => "rosctr_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "rosctr_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "rosctr_name" => "string"
+      }
+      on_error => "rosctr_name_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "rosctr_name_label.value.string_value" => "%{rosctr_name}"
+      }
+      on_error => "rosctr_name_not_found"
+    }
+
+    if ![rosctr_name_not_found] and
+      [rosctr_name_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "rosctr_name_label.key" => "rosctr_name"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "rosctr_name_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "subfunction_code" => "string"
+      }
+      on_error => "subfunction_code_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "subfunction_code_label.value.string_value" => "%{subfunction_code}"
+      }
+      on_error => "subfunction_code_not_found"
+    }
+
+    if ![subfunction_code_not_found] and
+      [subfunction_code_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "subfunction_code_label.key" => "subfunction_code"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "subfunction_code_label"
+        }
+      }
+    }
+
+    mutate {
+      convert => {
+        "subfunction_name" => "string"
+      }
+      on_error => "subfunction_name_conversion_error"
+    }
+
+    mutate {
+      replace => {
+        "subfunction_name_label.value.string_value" => "%{subfunction_name}"
+      }
+      on_error => "subfunction_name_not_found"
+    }
+
+    if ![subfunction_name_not_found] and
+      [subfunction_name_label][value][string_value] != "" {
+      mutate {
+        replace => {
+          "subfunction_name_label.key" => "subfunction_name"
+        }
+      }
+      mutate {
+        merge => {
+          "token_additional.fields" => "subfunction_name_label"
+        }
+      }
+    }
+
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -24251,7 +28636,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # smartpcap
+  # Smartpcap
 
   else if [_path] == "smartpcap" {
 
@@ -24272,7 +28657,8 @@ filter {
 
     grok {
       match => {
-        "logstr" => "Lever Failure:\\s*uid:%{DATA:data_uid}\\s*lever:%{DATA:lever_level}\\s*rule:%{DATA:rule_id}\\s+%{GREEDYDATA:lever_msg}"
+        "logstr" =>
+        "Lever Failure:\\s*uid:%{DATA:data_uid}\\s*lever:%{DATA:lever_level}\\s*rule:%{DATA:rule_id}\\s+%{GREEDYDATA:lever_msg}"
       }
       on_error => "logstr_not_match"
     }
@@ -24356,7 +28742,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # snmp
+  # Snmp
 
   else if [_path] == "snmp" {
 
@@ -24521,7 +28907,8 @@ filter {
       }
       on_error => "display_string_not_found"
     }
-    if ![display_string_not_found] and [display_string] != "" and [display_string] != "-" {
+    if ![display_string_not_found] and [display_string] != ""
+    and [display_string] != "-" {
       mutate {
         replace => {
           "display_string_labels.key" => "display_string"
@@ -24560,7 +28947,7 @@ filter {
       on_error => "snmp_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -24578,7 +28965,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # socks
+  # Socks
 
   else if [_path] == "socks" {
 
@@ -24787,7 +29174,7 @@ filter {
       on_error => "socks_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -24805,7 +29192,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # software
+  # Software
 
   else if [_path] == "software" {
 
@@ -25004,7 +29391,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # specific_dns_tunnels
+  # Specific_dns_tunnels
 
   else if [_path] == "specific_dns_tunnels" {
 
@@ -25213,8 +29600,8 @@ filter {
       on_error => "dns_tunnel_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
-    # occasional DNS logs include no question, we drop them as they have no pratical usage
+    # Check if required udm validation fields for NETWORK_DNS exist, if not set as NETWORK_UNCATEGORIZED.
+    # Occasional DNS logs include no question, we drop them as they have no pratical usage
     # UDM > Metadata > Event Type
     if [principal_present] == "true" and [question_check] != "" {
       mutate {
@@ -25240,7 +29627,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # stepping
+  # Stepping
 
   else if [_path] == "stepping" {
 
@@ -25420,7 +29807,7 @@ filter {
           "token_target.labels" => "server2_h_labels"
         }
       }
-    }    
+    }
 
     mutate {
       convert => {
@@ -25547,7 +29934,7 @@ filter {
       on_error => "stepping_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -25565,7 +29952,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # stun
+  # Stun
 
   else if [_path] == "stun" {
 
@@ -25581,7 +29968,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -25710,7 +30098,7 @@ filter {
       on_error => "stun_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -25728,7 +30116,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # stun_nat
+  # Stun_nat
 
   else if [_path] == "stun_nat" {
 
@@ -25744,7 +30132,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -25903,7 +30292,7 @@ filter {
       on_error => "stun_nat_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -25921,7 +30310,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # tds_sql_batch
+  # Tds_sql_batch
 
   else if [_path] == "tds_sql_batch" {
 
@@ -25987,7 +30376,7 @@ filter {
       on_error => "tds_sql_batch_about_not_found"
     }
 
-    # check if required udm validation fields for STATUS_UPDATE exist.
+    # Check if required udm validation fields for STATUS_UPDATE exist.
 
     if [principal_present] == "true" {
       mutate {
@@ -25999,7 +30388,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # traceroute
+  # Traceroute
 
   else if [_path] == "traceroute" {
 
@@ -26015,7 +30404,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -26089,7 +30479,7 @@ filter {
       }
     }
 
-    # check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_UNCATEGORIZED exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -26107,7 +30497,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # tunnel
+  # Tunnel
 
   else if [_path] == "tunnel" {
 
@@ -26136,7 +30526,8 @@ filter {
 
     mutate {
       replace => {
-        "tunnel_security_result.description" => "action %{action} on tunnel type %{tunnel_type}"
+        "tunnel_security_result.description" =>
+        "action %{action} on tunnel type %{tunnel_type}"
       }
       on_error => "action_not_found"
     }
@@ -26179,7 +30570,7 @@ filter {
     }
 
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -26197,7 +30588,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # unknown-smartpcap
+  # Unknown-smartpcap
 
   else if [_path] == "unknown-smartpcap" {
 
@@ -26277,7 +30668,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # vpn
+  # Vpn
 
   else if [_path] == "vpn" {
 
@@ -26293,7 +30684,8 @@ filter {
       mutate {
         uppercase => ["proto"]
       }
-      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM", "TCP", "UDP", "VRRP"] {
+      if [proto] in ["EIGRP","ESP", "GRE", "ICMP", "IGMP", "IP6IN4", "PIM",
+      "TCP", "UDP", "VRRP"] {
         mutate {
           replace => {
             "token_network.ip_protocol" => "%{proto}"
@@ -26383,7 +30775,7 @@ filter {
       }
       on_error => "server_name_not_found"
     }
-    
+
     mutate {
       replace => {
         "checkja3s" => "%{ja3s}"
@@ -26429,7 +30821,8 @@ filter {
 
     mutate {
       replace => {
-        "token_principal.location.country_or_region" => "%{orig_region} : %{orig_cc}"
+        "token_principal.location.country_or_region" =>
+        "%{orig_region} : %{orig_cc}"
       }
       on_error => "orig_region_orig_cc_not_found"
     }
@@ -26468,7 +30861,8 @@ filter {
 
     mutate {
       replace => {
-        "token_target.location.country_or_region" => "%{resp_region} : %{resp_cc}"
+        "token_target.location.country_or_region" =>
+        "%{resp_region} : %{resp_cc}"
       }
       on_error => "resp_region_resp_cc_not_found"
     }
@@ -26559,7 +30953,7 @@ filter {
       on_error => "vpn_about_not_found"
     }
 
-    # check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
+    # Check if required udm validation fields for NETWORK_CONNECTION exist, if not set as STATUS_UPDATE
     if [principal_present] == "true" and [target_present] == "true" {
       mutate {
         replace => {
@@ -26577,7 +30971,7 @@ filter {
   }
 
   # ----------------------------------------------------------------------
-  # suricata_stats
+  # Suricata_stats
 
   else if[_path] == "suricata_stats" {
 
@@ -26600,7 +30994,8 @@ filter {
     if ![not_valid_json] {
 
       date {
-        match => ["timestamp", "ISO8601", "RFC3339", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZ" ]
+        match =>
+        ["timestamp", "ISO8601", "RFC3339", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZZZ" ]
         on_error => "timestamp_not_found"
       }
 
@@ -26681,7 +31076,8 @@ filter {
         }
         on_error => "stats_napa_total_pkts_not_found"
       }
-      if ![stats_napa_total_pkts_not_found] and [stats][napa_total][pkts] != "" {
+      if ![stats_napa_total_pkts_not_found]
+      and [stats][napa_total][pkts] != "" {
         mutate {
           replace => {
             "stats_napa_total_pkts_labels.key" => "stats_napa_total_pkts"
@@ -26707,7 +31103,8 @@ filter {
         }
         on_error => "stats_napa_total_byte_not_found"
       }
-      if ![stats_napa_total_byte_not_found] and [stats][napa_total][byte] != "" {
+      if ![stats_napa_total_byte_not_found]
+      and [stats][napa_total][byte] != "" {
         mutate {
           replace => {
             "stats_napa_total_byte_labels.key" => "stats_napa_total_byte"
@@ -26729,19 +31126,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_total_overflow_drop_pkts_labels.value" => "%{stats.napa_total.overflow_drop_pkts}"
+          "stats_napa_total_overflow_drop_pkts_labels.value" =>
+          "%{stats.napa_total.overflow_drop_pkts}"
         }
         on_error => "stats_napa_total_overflow_drop_pkts_not_found"
       }
-      if ![stats_napa_total_overflow_drop_pkts_not_found] and [stats][napa_total][overflow_drop_pkts] != "" {
+      if ![stats_napa_total_overflow_drop_pkts_not_found]
+      and [stats][napa_total][overflow_drop_pkts] != "" {
         mutate {
           replace => {
-            "stats_napa_total_overflow_drop_pkts_labels.key" => "stats_napa_total_overflow_drop_pkts"
+            "stats_napa_total_overflow_drop_pkts_labels.key" =>
+            "stats_napa_total_overflow_drop_pkts"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_total_overflow_drop_pkts_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_total_overflow_drop_pkts_labels"
           }
         }
       }
@@ -26755,19 +31156,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_total_overflow_drop_byte_labels.value" => "%{stats.napa_total.overflow_drop_byte}"
+          "stats_napa_total_overflow_drop_byte_labels.value" =>
+           "%{stats.napa_total.overflow_drop_byte}"
         }
         on_error => "stats_napa_total_overflow_drop_byte_not_found"
       }
-      if ![stats_napa_total_overflow_drop_byte_not_found] and [stats][napa_total][overflow_drop_byte] != "" {
+      if ![stats_napa_total_overflow_drop_byte_not_found]
+      and [stats][napa_total][overflow_drop_byte] != "" {
         mutate {
           replace => {
-            "stats_napa_total_overflow_drop_byte_labels.key" => "stats_napa_total_overflow_drop_byte"
+            "stats_napa_total_overflow_drop_byte_labels.key" =>
+            "stats_napa_total_overflow_drop_byte"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_total_overflow_drop_byte_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_total_overflow_drop_byte_labels"
           }
         }
       }
@@ -26781,19 +31186,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_dispatch_host_pkts_labels.value" => "%{stats.napa_dispatch_host.pkts}"
+          "stats_napa_dispatch_host_pkts_labels.value" =>
+          "%{stats.napa_dispatch_host.pkts}"
         }
         on_error => "stats_napa_dispatch_host_pkts_not_found"
       }
-      if ![stats_napa_dispatch_host_pkts_not_found] and [stats][napa_dispatch_host][pkts] != "" {
+      if ![stats_napa_dispatch_host_pkts_not_found]
+      and [stats][napa_dispatch_host][pkts] != "" {
         mutate {
           replace => {
-            "stats_napa_dispatch_host_pkts_labels.key" => "stats_napa_dispatch_host_pkts"
+            "stats_napa_dispatch_host_pkts_labels.key" =>
+            "stats_napa_dispatch_host_pkts"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_dispatch_host_pkts_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_dispatch_host_pkts_labels"
           }
         }
       }
@@ -26807,19 +31216,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_dispatch_host_byte_labels.value" => "%{stats.napa_dispatch_host.byte}"
+          "stats_napa_dispatch_host_byte_labels.value" =>
+          "%{stats.napa_dispatch_host.byte}"
         }
         on_error => "stats_napa_dispatch_host_byte_not_found"
       }
-      if ![stats_napa_dispatch_host_byte_not_found] and [stats][napa_dispatch_host][byte] != "" {
+      if ![stats_napa_dispatch_host_byte_not_found]
+      and [stats][napa_dispatch_host][byte] != "" {
         mutate {
           replace => {
-            "stats_napa_dispatch_host_byte_labels.key" => "stats_napa_dispatch_host_byte"
+            "stats_napa_dispatch_host_byte_labels.key" =>
+            "stats_napa_dispatch_host_byte"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_dispatch_host_byte_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_dispatch_host_byte_labels"
           }
         }
       }
@@ -26833,19 +31246,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_dispatch_drop_pkts_labels.value" => "%{stats.napa_dispatch_drop.pkts}"
+          "stats_napa_dispatch_drop_pkts_labels.value" =>
+          "%{stats.napa_dispatch_drop.pkts}"
         }
         on_error => "stats_napa_dispatch_drop_pkts_not_found"
       }
-      if ![stats_napa_dispatch_drop_pkts_not_found] and [stats][napa_dispatch_drop][pkts] != "" {
+      if ![stats_napa_dispatch_drop_pkts_not_found]
+      and [stats][napa_dispatch_drop][pkts] != "" {
         mutate {
           replace => {
-            "stats_napa_dispatch_drop_pkts_labels.key" => "stats_napa_dispatch_drop_pkts"
+            "stats_napa_dispatch_drop_pkts_labels.key" =>
+            "stats_napa_dispatch_drop_pkts"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_dispatch_drop_pkts_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_dispatch_drop_pkts_labels"
           }
         }
       }
@@ -26859,19 +31276,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_napa_dispatch_drop_byte_labels.value" => "%{stats.napa_dispatch_drop.byte}"
+          "stats_napa_dispatch_drop_byte_labels.value" =>
+          "%{stats.napa_dispatch_drop.byte}"
         }
         on_error => "stats_napa_dispatch_drop_byte_not_found"
       }
-      if ![stats_napa_dispatch_drop_byte_not_found] and [stats][napa_dispatch_drop][byte] != "" {
+      if ![stats_napa_dispatch_drop_byte_not_found]
+      and [stats][napa_dispatch_drop][byte] != "" {
         mutate {
           replace => {
-            "stats_napa_dispatch_drop_byte_labels.key" => "stats_napa_dispatch_drop_byte"
+            "stats_napa_dispatch_drop_byte_labels.key" =>
+            "stats_napa_dispatch_drop_byte"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_napa_dispatch_drop_byte_labels"
+            "suricata_stats_about.labels" =>
+            "stats_napa_dispatch_drop_byte_labels"
           }
         }
       }
@@ -26941,7 +31362,8 @@ filter {
         }
         on_error => "stats_decoder_invalid_not_found"
       }
-      if ![stats_decoder_invalid_not_found] and [stats][decoder][invalid] != "" {
+      if ![stats_decoder_invalid_not_found]
+      and [stats][decoder][invalid] != "" {
         mutate {
           replace => {
             "stats_decoder_invalid_labels.key" => "stats_decoder_invalid"
@@ -27019,7 +31441,8 @@ filter {
         }
         on_error => "stats_decoder_ethernet_not_found"
       }
-      if ![stats_decoder_ethernet_not_found] and [stats][decoder][ethernet] != "" {
+      if ![stats_decoder_ethernet_not_found]
+      and [stats][decoder][ethernet] != "" {
         mutate {
           replace => {
             "stats_decoder_ethernet_labels.key" => "stats_decoder_ethernet"
@@ -27409,7 +31832,8 @@ filter {
         }
         on_error => "stats_decoder_vlan_qinq_not_found"
       }
-      if ![stats_decoder_vlan_qinq_not_found] and [stats][decoder][vlan_qinq] != "" {
+      if ![stats_decoder_vlan_qinq_not_found]
+      and [stats][decoder][vlan_qinq] != "" {
         mutate {
           replace => {
             "stats_decoder_vlan_qinq_labels.key" => "stats_decoder_vlan_qinq"
@@ -27487,7 +31911,8 @@ filter {
         }
         on_error => "stats_decoder_ieee8021ah_not_found"
       }
-      if ![stats_decoder_ieee8021ah_not_found] and [stats][decoder][ieee8021ah] != "" {
+      if ![stats_decoder_ieee8021ah_not_found]
+      and [stats][decoder][ieee8021ah] != "" {
         mutate {
           replace => {
             "stats_decoder_ieee8021ah_labels.key" => "stats_decoder_ieee8021ah"
@@ -27535,14 +31960,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_ipv4_in_ipv6_labels.value" => "%{stats.decoder.ipv4_in_ipv6}"
+          "stats_decoder_ipv4_in_ipv6_labels.value" =>
+          "%{stats.decoder.ipv4_in_ipv6}"
         }
         on_error => "stats_decoder_ipv4_in_ipv6_not_found"
       }
-      if ![stats_decoder_ipv4_in_ipv6_not_found] and [stats][decoder][ipv4_in_ipv6] != "" {
+      if ![stats_decoder_ipv4_in_ipv6_not_found]
+      and [stats][decoder][ipv4_in_ipv6] != "" {
         mutate {
           replace => {
-            "stats_decoder_ipv4_in_ipv6_labels.key" => "stats_decoder_ipv4_in_ipv6"
+            "stats_decoder_ipv4_in_ipv6_labels.key" =>
+            "stats_decoder_ipv4_in_ipv6"
           }
         }
         mutate {
@@ -27561,14 +31989,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_ipv6_in_ipv6_labels.value" => "%{stats.decoder.ipv6_in_ipv6}"
+          "stats_decoder_ipv6_in_ipv6_labels.value" =>
+          "%{stats.decoder.ipv6_in_ipv6}"
         }
         on_error => "stats_decoder_ipv6_in_ipv6_not_found"
       }
-      if ![stats_decoder_ipv6_in_ipv6_not_found] and [stats][decoder][ipv6_in_ipv6] != "" {
+      if ![stats_decoder_ipv6_in_ipv6_not_found]
+      and [stats][decoder][ipv6_in_ipv6] != "" {
         mutate {
           replace => {
-            "stats_decoder_ipv6_in_ipv6_labels.key" => "stats_decoder_ipv6_in_ipv6"
+            "stats_decoder_ipv6_in_ipv6_labels.key" =>
+            "stats_decoder_ipv6_in_ipv6"
           }
         }
         mutate {
@@ -27613,14 +32044,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_avg_pkt_size_labels.value" => "%{stats.decoder.avg_pkt_size}"
+          "stats_decoder_avg_pkt_size_labels.value" =>
+          "%{stats.decoder.avg_pkt_size}"
         }
         on_error => "stats_decoder_avg_pkt_size_not_found"
       }
-      if ![stats_decoder_avg_pkt_size_not_found] and [stats][decoder][avg_pkt_size] != "" {
+      if ![stats_decoder_avg_pkt_size_not_found]
+      and [stats][decoder][avg_pkt_size] != "" {
         mutate {
           replace => {
-            "stats_decoder_avg_pkt_size_labels.key" => "stats_decoder_avg_pkt_size"
+            "stats_decoder_avg_pkt_size_labels.key" =>
+            "stats_decoder_avg_pkt_size"
           }
         }
         mutate {
@@ -27639,14 +32073,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_max_pkt_size_labels.value" => "%{stats.decoder.max_pkt_size}"
+          "stats_decoder_max_pkt_size_labels.value" =>
+          "%{stats.decoder.max_pkt_size}"
         }
         on_error => "stats_decoder_max_pkt_size_not_found"
       }
-      if ![stats_decoder_max_pkt_size_not_found] and [stats][decoder][max_pkt_size] != "" {
+      if ![stats_decoder_max_pkt_size_not_found]
+      and [stats][decoder][max_pkt_size] != "" {
         mutate {
           replace => {
-            "stats_decoder_max_pkt_size_labels.key" => "stats_decoder_max_pkt_size"
+            "stats_decoder_max_pkt_size_labels.key" =>
+            "stats_decoder_max_pkt_size"
           }
         }
         mutate {
@@ -27665,19 +32102,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_max_mac_addrs_src_labels.value" => "%{stats.decoder.max_mac_addrs_src}"
+          "stats_decoder_max_mac_addrs_src_labels.value" =>
+          "%{stats.decoder.max_mac_addrs_src}"
         }
         on_error => "stats_decoder_max_mac_addrs_src_not_found"
       }
-      if ![stats_decoder_max_mac_addrs_src_not_found] and [stats][decoder][max_mac_addrs_src] != "" {
+      if ![stats_decoder_max_mac_addrs_src_not_found]
+      and [stats][decoder][max_mac_addrs_src] != "" {
         mutate {
           replace => {
-            "stats_decoder_max_mac_addrs_src_labels.key" => "stats_decoder_max_mac_addrs_src"
+            "stats_decoder_max_mac_addrs_src_labels.key" =>
+            "stats_decoder_max_mac_addrs_src"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_max_mac_addrs_src_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_max_mac_addrs_src_labels"
           }
         }
       }
@@ -27691,19 +32132,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_max_mac_addrs_dst_labels.value" => "%{stats.decoder.max_mac_addrs_dst}"
+          "stats_decoder_max_mac_addrs_dst_labels.value" =>
+          "%{stats.decoder.max_mac_addrs_dst}"
         }
         on_error => "stats_decoder_max_mac_addrs_dst_not_found"
       }
-      if ![stats_decoder_max_mac_addrs_dst_not_found] and [stats][decoder][max_mac_addrs_dst] != "" {
+      if ![stats_decoder_max_mac_addrs_dst_not_found]
+      and [stats][decoder][max_mac_addrs_dst] != "" {
         mutate {
           replace => {
-            "stats_decoder_max_mac_addrs_dst_labels.key" => "stats_decoder_max_mac_addrs_dst"
+            "stats_decoder_max_mac_addrs_dst_labels.key" =>
+            "stats_decoder_max_mac_addrs_dst"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_max_mac_addrs_dst_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_max_mac_addrs_dst_labels"
           }
         }
       }
@@ -27743,19 +32188,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_pkt_too_small_labels.value" => "%{stats.decoder.event.ipv4.pkt_too_small}"
+          "stats_decoder_event_ipv4_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ipv4.pkt_too_small}"
         }
         on_error => "stats_decoder_event_ipv4_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ipv4_pkt_too_small_not_found] and [stats][decoder][event][ipv4][pkt_too_small] != "" {
+      if ![stats_decoder_event_ipv4_pkt_too_small_not_found]
+      and [stats][decoder][event][ipv4][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_pkt_too_small_labels.key" => "stats_decoder_event_ipv4_pkt_too_small"
+            "stats_decoder_event_ipv4_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ipv4_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_pkt_too_small_labels"
           }
         }
       }
@@ -27769,19 +32218,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_hlen_too_small_labels.value" => "%{stats.decoder.event.ipv4.hlen_too_small}"
+          "stats_decoder_event_ipv4_hlen_too_small_labels.value" =>
+          "%{stats.decoder.event.ipv4.hlen_too_small}"
         }
         on_error => "stats_decoder_event_ipv4_hlen_too_small_not_found"
       }
-      if ![stats_decoder_event_ipv4_hlen_too_small_not_found] and [stats][decoder][event][ipv4][hlen_too_small] != "" {
+      if ![stats_decoder_event_ipv4_hlen_too_small_not_found]
+      and [stats][decoder][event][ipv4][hlen_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_hlen_too_small_labels.key" => "stats_decoder_event_ipv4_hlen_too_small"
+            "stats_decoder_event_ipv4_hlen_too_small_labels.key" =>
+            "stats_decoder_event_ipv4_hlen_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_hlen_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_hlen_too_small_labels"
           }
         }
       }
@@ -27790,24 +32243,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv4.iplen_smaller_than_hlen" => "string"
         }
-        on_error => "stats_decoder_event_ipv4_iplen_smaller_than_hlen_conversion_error"
+        on_error => "ipv4_iplen_smaller_than_hlen_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels.value" => "%{stats.decoder.event.ipv4.iplen_smaller_than_hlen}"
+          "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels.value" =>
+          "%{stats.decoder.event.ipv4.iplen_smaller_than_hlen}"
         }
         on_error => "stats_decoder_event_ipv4_iplen_smaller_than_hlen_not_found"
       }
-      if ![stats_decoder_event_ipv4_iplen_smaller_than_hlen_not_found] and [stats][decoder][event][ipv4][iplen_smaller_than_hlen] != "" {
+      if ![stats_decoder_event_ipv4_iplen_smaller_than_hlen_not_found]
+      and [stats][decoder][event][ipv4][iplen_smaller_than_hlen] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels.key" => "stats_decoder_event_ipv4_iplen_smaller_than_hlen"
+            "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels.key" =>
+            "stats_decoder_event_ipv4_iplen_smaller_than_hlen"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_iplen_smaller_than_hlen_labels"
           }
         }
       }
@@ -27821,19 +32278,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_trunc_pkt_labels.value" => "%{stats.decoder.event.ipv4.trunc_pkt}"
+          "stats_decoder_event_ipv4_trunc_pkt_labels.value" =>
+          "%{stats.decoder.event.ipv4.trunc_pkt}"
         }
         on_error => "stats_decoder_event_ipv4_trunc_pkt_not_found"
       }
-      if ![stats_decoder_event_ipv4_trunc_pkt_not_found] and [stats][decoder][event][ipv4][trunc_pkt] != "" {
+      if ![stats_decoder_event_ipv4_trunc_pkt_not_found]
+      and [stats][decoder][event][ipv4][trunc_pkt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_trunc_pkt_labels.key" => "stats_decoder_event_ipv4_trunc_pkt"
+            "stats_decoder_event_ipv4_trunc_pkt_labels.key" =>
+            "stats_decoder_event_ipv4_trunc_pkt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_trunc_pkt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_trunc_pkt_labels"
           }
         }
       }
@@ -27847,19 +32308,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_invalid_labels.value" => "%{stats.decoder.event.ipv4.opt_invalid}"
+          "stats_decoder_event_ipv4_opt_invalid_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_invalid}"
         }
         on_error => "stats_decoder_event_ipv4_opt_invalid_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_invalid_not_found] and [stats][decoder][event][ipv4][opt_invalid] != "" {
+      if ![stats_decoder_event_ipv4_opt_invalid_not_found]
+      and [stats][decoder][event][ipv4][opt_invalid] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_invalid_labels.key" => "stats_decoder_event_ipv4_opt_invalid"
+            "stats_decoder_event_ipv4_opt_invalid_labels.key" =>
+            "stats_decoder_event_ipv4_opt_invalid"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_invalid_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_invalid_labels"
           }
         }
       }
@@ -27873,19 +32338,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_invalid_len_labels.value" => "%{stats.decoder.event.ipv4.opt_invalid_len}"
+          "stats_decoder_event_ipv4_opt_invalid_len_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_invalid_len}"
         }
         on_error => "stats_decoder_event_ipv4_opt_invalid_len_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_invalid_len_not_found] and [stats][decoder][event][ipv4][opt_invalid_len] != "" {
+      if ![stats_decoder_event_ipv4_opt_invalid_len_not_found]
+      and [stats][decoder][event][ipv4][opt_invalid_len] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_invalid_len_labels.key" => "stats_decoder_event_ipv4_opt_invalid_len"
+            "stats_decoder_event_ipv4_opt_invalid_len_labels.key" =>
+            "stats_decoder_event_ipv4_opt_invalid_len"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_invalid_len_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_invalid_len_labels"
           }
         }
       }
@@ -27899,19 +32368,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_malformed_labels.value" => "%{stats.decoder.event.ipv4.opt_malformed}"
+          "stats_decoder_event_ipv4_opt_malformed_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_malformed}"
         }
         on_error => "stats_decoder_event_ipv4_opt_malformed_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_malformed_not_found] and [stats][decoder][event][ipv4][opt_malformed] != "" {
+      if ![stats_decoder_event_ipv4_opt_malformed_not_found]
+      and [stats][decoder][event][ipv4][opt_malformed] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_malformed_labels.key" => "stats_decoder_event_ipv4_opt_malformed"
+            "stats_decoder_event_ipv4_opt_malformed_labels.key" =>
+            "stats_decoder_event_ipv4_opt_malformed"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_malformed_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_malformed_labels"
           }
         }
       }
@@ -27925,19 +32398,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_pad_required_labels.value" => "%{stats.decoder.event.ipv4.opt_pad_required}"
+          "stats_decoder_event_ipv4_opt_pad_required_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_pad_required}"
         }
         on_error => "stats_decoder_event_ipv4_opt_pad_required_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_pad_required_not_found] and [stats][decoder][event][ipv4][opt_pad_required] != "" {
+      if ![stats_decoder_event_ipv4_opt_pad_required_not_found]
+      and [stats][decoder][event][ipv4][opt_pad_required] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_pad_required_labels.key" => "stats_decoder_event_ipv4_opt_pad_required"
+            "stats_decoder_event_ipv4_opt_pad_required_labels.key" =>
+            "stats_decoder_event_ipv4_opt_pad_required"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_pad_required_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_pad_required_labels"
           }
         }
       }
@@ -27951,19 +32428,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_eol_required_labels.value" => "%{stats.decoder.event.ipv4.opt_eol_required}"
+          "stats_decoder_event_ipv4_opt_eol_required_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_eol_required}"
         }
         on_error => "stats_decoder_event_ipv4_opt_eol_required_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_eol_required_not_found] and [stats][decoder][event][ipv4][opt_eol_required] != "" {
+      if ![stats_decoder_event_ipv4_opt_eol_required_not_found]
+      and [stats][decoder][event][ipv4][opt_eol_required] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_eol_required_labels.key" => "stats_decoder_event_ipv4_opt_eol_required"
+            "stats_decoder_event_ipv4_opt_eol_required_labels.key" =>
+            "stats_decoder_event_ipv4_opt_eol_required"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_eol_required_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_eol_required_labels"
           }
         }
       }
@@ -27977,19 +32458,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_duplicate_labels.value" => "%{stats.decoder.event.ipv4.opt_duplicate}"
+          "stats_decoder_event_ipv4_opt_duplicate_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_duplicate}"
         }
         on_error => "stats_decoder_event_ipv4_opt_duplicate_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_duplicate_not_found] and [stats][decoder][event][ipv4][opt_duplicate] != "" {
+      if ![stats_decoder_event_ipv4_opt_duplicate_not_found]
+      and [stats][decoder][event][ipv4][opt_duplicate] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_duplicate_labels.key" => "stats_decoder_event_ipv4_opt_duplicate"
+            "stats_decoder_event_ipv4_opt_duplicate_labels.key" =>
+            "stats_decoder_event_ipv4_opt_duplicate"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_duplicate_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_duplicate_labels"
           }
         }
       }
@@ -28003,19 +32488,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_opt_unknown_labels.value" => "%{stats.decoder.event.ipv4.opt_unknown}"
+          "stats_decoder_event_ipv4_opt_unknown_labels.value" =>
+          "%{stats.decoder.event.ipv4.opt_unknown}"
         }
         on_error => "stats_decoder_event_ipv4_opt_unknown_not_found"
       }
-      if ![stats_decoder_event_ipv4_opt_unknown_not_found] and [stats][decoder][event][ipv4][opt_unknown] != "" {
+      if ![stats_decoder_event_ipv4_opt_unknown_not_found]
+      and [stats][decoder][event][ipv4][opt_unknown] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_opt_unknown_labels.key" => "stats_decoder_event_ipv4_opt_unknown"
+            "stats_decoder_event_ipv4_opt_unknown_labels.key" =>
+            "stats_decoder_event_ipv4_opt_unknown"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_opt_unknown_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_opt_unknown_labels"
           }
         }
       }
@@ -28029,19 +32518,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_wrong_ip_version_labels.value" => "%{stats.decoder.event.ipv4.wrong_ip_version}"
+          "stats_decoder_event_ipv4_wrong_ip_version_labels.value" =>
+          "%{stats.decoder.event.ipv4.wrong_ip_version}"
         }
         on_error => "stats_decoder_event_ipv4_wrong_ip_version_not_found"
       }
-      if ![stats_decoder_event_ipv4_wrong_ip_version_not_found] and [stats][decoder][event][ipv4][wrong_ip_version] != "" {
+      if ![stats_decoder_event_ipv4_wrong_ip_version_not_found]
+      and [stats][decoder][event][ipv4][wrong_ip_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_wrong_ip_version_labels.key" => "stats_decoder_event_ipv4_wrong_ip_version"
+            "stats_decoder_event_ipv4_wrong_ip_version_labels.key" =>
+            "stats_decoder_event_ipv4_wrong_ip_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_wrong_ip_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_wrong_ip_version_labels"
           }
         }
       }
@@ -28055,19 +32548,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_icmpv6_labels.value" => "%{stats.decoder.event.ipv4.icmpv6}"
+          "stats_decoder_event_ipv4_icmpv6_labels.value" =>
+          "%{stats.decoder.event.ipv4.icmpv6}"
         }
         on_error => "stats_decoder_event_ipv4_icmpv6_not_found"
       }
-      if ![stats_decoder_event_ipv4_icmpv6_not_found] and [stats][decoder][event][ipv4][icmpv6] != "" {
+      if ![stats_decoder_event_ipv4_icmpv6_not_found]
+      and [stats][decoder][event][ipv4][icmpv6] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_icmpv6_labels.key" => "stats_decoder_event_ipv4_icmpv6"
+            "stats_decoder_event_ipv4_icmpv6_labels.key" =>
+            "stats_decoder_event_ipv4_icmpv6"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_icmpv6_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_icmpv6_labels"
           }
         }
       }
@@ -28076,24 +32573,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv4.frag_pkt_too_large" => "string"
         }
-        on_error => "stats_decoder_event_ipv4_frag_pkt_too_large_conversion_error"
+        on_error => "frag_pkt_too_large_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_frag_pkt_too_large_labels.value" => "%{stats.decoder.event.ipv4.frag_pkt_too_large}"
+          "stats_decoder_event_ipv4_frag_pkt_too_large_labels.value" =>
+          "%{stats.decoder.event.ipv4.frag_pkt_too_large}"
         }
         on_error => "stats_decoder_event_ipv4_frag_pkt_too_large_not_found"
       }
-      if ![stats_decoder_event_ipv4_frag_pkt_too_large_not_found] and [stats][decoder][event][ipv4][frag_pkt_too_large] != "" {
+      if ![stats_decoder_event_ipv4_frag_pkt_too_large_not_found]
+      and [stats][decoder][event][ipv4][frag_pkt_too_large] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_frag_pkt_too_large_labels.key" => "stats_decoder_event_ipv4_frag_pkt_too_large"
+            "stats_decoder_event_ipv4_frag_pkt_too_large_labels.key" =>
+            "stats_decoder_event_ipv4_frag_pkt_too_large"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_frag_pkt_too_large_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_frag_pkt_too_large_labels"
           }
         }
       }
@@ -28107,19 +32608,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_frag_overlap_labels.value" => "%{stats.decoder.event.ipv4.frag_overlap}"
+          "stats_decoder_event_ipv4_frag_overlap_labels.value" =>
+          "%{stats.decoder.event.ipv4.frag_overlap}"
         }
         on_error => "stats_decoder_event_ipv4_frag_overlap_not_found"
       }
-      if ![stats_decoder_event_ipv4_frag_overlap_not_found] and [stats][decoder][event][ipv4][frag_overlap] != "" {
+      if ![stats_decoder_event_ipv4_frag_overlap_not_found]
+      and [stats][decoder][event][ipv4][frag_overlap] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_frag_overlap_labels.key" => "stats_decoder_event_ipv4_frag_overlap"
+            "stats_decoder_event_ipv4_frag_overlap_labels.key" =>
+            "stats_decoder_event_ipv4_frag_overlap"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_frag_overlap_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_frag_overlap_labels"
           }
         }
       }
@@ -28133,19 +32638,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv4_frag_ignored_labels.value" => "%{stats.decoder.event.ipv4.frag_ignored}"
+          "stats_decoder_event_ipv4_frag_ignored_labels.value" =>
+          "%{stats.decoder.event.ipv4.frag_ignored}"
         }
         on_error => "stats_decoder_event_ipv4_frag_ignored_not_found"
       }
-      if ![stats_decoder_event_ipv4_frag_ignored_not_found] and [stats][decoder][event][ipv4][frag_ignored] != "" {
+      if ![stats_decoder_event_ipv4_frag_ignored_not_found]
+      and [stats][decoder][event][ipv4][frag_ignored] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv4_frag_ignored_labels.key" => "stats_decoder_event_ipv4_frag_ignored"
+            "stats_decoder_event_ipv4_frag_ignored_labels.key" =>
+            "stats_decoder_event_ipv4_frag_ignored"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv4_frag_ignored_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv4_frag_ignored_labels"
           }
         }
       }
@@ -28159,19 +32668,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv4_pkt_too_small_labels.value" => "%{stats.decoder.event.icmpv4.pkt_too_small}"
+          "stats_decoder_event_icmpv4_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.icmpv4.pkt_too_small}"
         }
         on_error => "stats_decoder_event_icmpv4_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_icmpv4_pkt_too_small_not_found] and [stats][decoder][event][icmpv4][pkt_too_small] != "" {
+      if ![stats_decoder_event_icmpv4_pkt_too_small_not_found]
+      and [stats][decoder][event][icmpv4][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv4_pkt_too_small_labels.key" => "stats_decoder_event_icmpv4_pkt_too_small"
+            "stats_decoder_event_icmpv4_pkt_too_small_labels.key" =>
+            "stats_decoder_event_icmpv4_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv4_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv4_pkt_too_small_labels"
           }
         }
       }
@@ -28185,19 +32698,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv4_unknown_type_labels.value" => "%{stats.decoder.event.icmpv4.unknown_type}"
+          "stats_decoder_event_icmpv4_unknown_type_labels.value" =>
+          "%{stats.decoder.event.icmpv4.unknown_type}"
         }
         on_error => "stats_decoder_event_icmpv4_unknown_type_not_found"
       }
-      if ![stats_decoder_event_icmpv4_unknown_type_not_found] and [stats][decoder][event][icmpv4][unknown_type] != "" {
+      if ![stats_decoder_event_icmpv4_unknown_type_not_found]
+      and [stats][decoder][event][icmpv4][unknown_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv4_unknown_type_labels.key" => "stats_decoder_event_icmpv4_unknown_type"
+            "stats_decoder_event_icmpv4_unknown_type_labels.key" =>
+            "stats_decoder_event_icmpv4_unknown_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv4_unknown_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv4_unknown_type_labels"
           }
         }
       }
@@ -28211,19 +32728,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv4_unknown_code_labels.value" => "%{stats.decoder.event.icmpv4.unknown_code}"
+          "stats_decoder_event_icmpv4_unknown_code_labels.value" =>
+          "%{stats.decoder.event.icmpv4.unknown_code}"
         }
         on_error => "stats_decoder_event_icmpv4_unknown_code_not_found"
       }
-      if ![stats_decoder_event_icmpv4_unknown_code_not_found] and [stats][decoder][event][icmpv4][unknown_code] != "" {
+      if ![stats_decoder_event_icmpv4_unknown_code_not_found]
+      and [stats][decoder][event][icmpv4][unknown_code] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv4_unknown_code_labels.key" => "stats_decoder_event_icmpv4_unknown_code"
+            "stats_decoder_event_icmpv4_unknown_code_labels.key" =>
+            "stats_decoder_event_icmpv4_unknown_code"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv4_unknown_code_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv4_unknown_code_labels"
           }
         }
       }
@@ -28237,19 +32758,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels.value" => "%{stats.decoder.event.icmpv4.ipv4_trunc_pkt}"
+          "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels.value" =>
+          "%{stats.decoder.event.icmpv4.ipv4_trunc_pkt}"
         }
         on_error => "stats_decoder_event_icmpv4_ipv4_trunc_pkt_not_found"
       }
-      if ![stats_decoder_event_icmpv4_ipv4_trunc_pkt_not_found] and [stats][decoder][event][icmpv4][ipv4_trunc_pkt] != "" {
+      if ![stats_decoder_event_icmpv4_ipv4_trunc_pkt_not_found]
+       and [stats][decoder][event][icmpv4][ipv4_trunc_pkt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels.key" => "stats_decoder_event_icmpv4_ipv4_trunc_pkt"
+            "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels.key" =>
+            "stats_decoder_event_icmpv4_ipv4_trunc_pkt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv4_ipv4_trunc_pkt_labels"
           }
         }
       }
@@ -28258,24 +32783,28 @@ filter {
         convert => {
           "stats.decoder.event.icmpv4.ipv4_unknown_ver" => "string"
         }
-        on_error => "stats_decoder_event_icmpv4_ipv4_unknown_ver_conversion_error"
+        on_error => "ipv4_unknown_ver_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels.value" => "%{stats.decoder.event.icmpv4.ipv4_unknown_ver}"
+          "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels.value" =>
+          "%{stats.decoder.event.icmpv4.ipv4_unknown_ver}"
         }
         on_error => "stats_decoder_event_icmpv4_ipv4_unknown_ver_not_found"
       }
-      if ![stats_decoder_event_icmpv4_ipv4_unknown_ver_not_found] and [stats][decoder][event][icmpv4][ipv4_unknown_ver] != "" {
+      if ![stats_decoder_event_icmpv4_ipv4_unknown_ver_not_found]
+      and [stats][decoder][event][icmpv4][ipv4_unknown_ver] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels.key" => "stats_decoder_event_icmpv4_ipv4_unknown_ver"
+            "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels.key" =>
+            "stats_decoder_event_icmpv4_ipv4_unknown_ver"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv4_ipv4_unknown_ver_labels"
           }
         }
       }
@@ -28289,19 +32818,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_unknown_type_labels.value" => "%{stats.decoder.event.icmpv6.unknown_type}"
+          "stats_decoder_event_icmpv6_unknown_type_labels.value" =>
+          "%{stats.decoder.event.icmpv6.unknown_type}"
         }
         on_error => "stats_decoder_event_icmpv6_unknown_type_not_found"
       }
-      if ![stats_decoder_event_icmpv6_unknown_type_not_found] and [stats][decoder][event][icmpv6][unknown_type] != "" {
+      if ![stats_decoder_event_icmpv6_unknown_type_not_found]
+      and [stats][decoder][event][icmpv6][unknown_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_unknown_type_labels.key" => "stats_decoder_event_icmpv6_unknown_type"
+            "stats_decoder_event_icmpv6_unknown_type_labels.key" =>
+            "stats_decoder_event_icmpv6_unknown_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_unknown_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_unknown_type_labels"
           }
         }
       }
@@ -28315,19 +32848,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_unknown_code_labels.value" => "%{stats.decoder.event.icmpv6.unknown_code}"
+          "stats_decoder_event_icmpv6_unknown_code_labels.value" =>
+          "%{stats.decoder.event.icmpv6.unknown_code}"
         }
         on_error => "stats_decoder_event_icmpv6_unknown_code_not_found"
       }
-      if ![stats_decoder_event_icmpv6_unknown_code_not_found] and [stats][decoder][event][icmpv6][unknown_code] != "" {
+      if ![stats_decoder_event_icmpv6_unknown_code_not_found]
+      and [stats][decoder][event][icmpv6][unknown_code] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_unknown_code_labels.key" => "stats_decoder_event_icmpv6_unknown_code"
+            "stats_decoder_event_icmpv6_unknown_code_labels.key" =>
+            "stats_decoder_event_icmpv6_unknown_code"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_unknown_code_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_unknown_code_labels"
           }
         }
       }
@@ -28341,19 +32878,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_pkt_too_small_labels.value" => "%{stats.decoder.event.icmpv6.pkt_too_small}"
+          "stats_decoder_event_icmpv6_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.icmpv6.pkt_too_small}"
         }
         on_error => "stats_decoder_event_icmpv6_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_icmpv6_pkt_too_small_not_found] and [stats][decoder][event][icmpv6][pkt_too_small] != "" {
+      if ![stats_decoder_event_icmpv6_pkt_too_small_not_found]
+      and [stats][decoder][event][icmpv6][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_pkt_too_small_labels.key" => "stats_decoder_event_icmpv6_pkt_too_small"
+            "stats_decoder_event_icmpv6_pkt_too_small_labels.key" =>
+            "stats_decoder_event_icmpv6_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_pkt_too_small_labels"
           }
         }
       }
@@ -28362,24 +32903,28 @@ filter {
         convert => {
           "stats.decoder.event.icmpv6.ipv6_unknown_version" => "string"
         }
-        on_error => "stats_decoder_event_icmpv6_ipv6_unknown_version_conversion_error"
+        on_error => "ipv6_unknown_version_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_ipv6_unknown_version_labels.value" => "%{stats.decoder.event.icmpv6.ipv6_unknown_version}"
+          "stats_decoder_event_icmpv6_ipv6_unknown_version_labels.value" =>
+          "%{stats.decoder.event.icmpv6.ipv6_unknown_version}"
         }
         on_error => "stats_decoder_event_icmpv6_ipv6_unknown_version_not_found"
       }
-      if ![stats_decoder_event_icmpv6_ipv6_unknown_version_not_found] and [stats][decoder][event][icmpv6][ipv6_unknown_version] != "" {
+      if ![stats_decoder_event_icmpv6_ipv6_unknown_version_not_found]
+      and [stats][decoder][event][icmpv6][ipv6_unknown_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_ipv6_unknown_version_labels.key" => "stats_decoder_event_icmpv6_ipv6_unknown_version"
+            "stats_decoder_event_icmpv6_ipv6_unknown_version_labels.key" =>
+            "stats_decoder_event_icmpv6_ipv6_unknown_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_ipv6_unknown_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_ipv6_unknown_version_labels"
           }
         }
       }
@@ -28393,19 +32938,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels.value" => "%{stats.decoder.event.icmpv6.ipv6_trunc_pkt}"
+          "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels.value" =>
+          "%{stats.decoder.event.icmpv6.ipv6_trunc_pkt}"
         }
         on_error => "stats_decoder_event_icmpv6_ipv6_trunc_pkt_not_found"
       }
-      if ![stats_decoder_event_icmpv6_ipv6_trunc_pkt_not_found] and [stats][decoder][event][icmpv6][ipv6_trunc_pkt] != "" {
+      if ![stats_decoder_event_icmpv6_ipv6_trunc_pkt_not_found]
+      and [stats][decoder][event][icmpv6][ipv6_trunc_pkt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels.key" => "stats_decoder_event_icmpv6_ipv6_trunc_pkt"
+            "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels.key" =>
+            "stats_decoder_event_icmpv6_ipv6_trunc_pkt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_ipv6_trunc_pkt_labels"
           }
         }
       }
@@ -28414,24 +32963,29 @@ filter {
         convert => {
           "stats.decoder.event.icmpv6.mld_message_with_invalid_hl" => "string"
         }
-        on_error => "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_conversion_error"
+        on_error => "mld_message_with_invalid_hl_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels.value" => "%{stats.decoder.event.icmpv6.mld_message_with_invalid_hl}"
+          "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels.value"
+          => "%{stats.decoder.event.icmpv6.mld_message_with_invalid_hl}"
         }
-        on_error => "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_not_found"
+        on_error =>
+        "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_not_found"
       }
-      if ![stats_decoder_event_icmpv6_mld_message_with_invalid_hl_not_found] and [stats][decoder][event][icmpv6][mld_message_with_invalid_hl] != "" {
+      if ![stats_decoder_event_icmpv6_mld_message_with_invalid_hl_not_found]
+      and [stats][decoder][event][icmpv6][mld_message_with_invalid_hl] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels.key" => "stats_decoder_event_icmpv6_mld_message_with_invalid_hl"
+            "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels.key"
+            => "stats_decoder_event_icmpv6_mld_message_with_invalid_hl"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_mld_message_with_invalid_hl_labels"
           }
         }
       }
@@ -28440,24 +32994,28 @@ filter {
         convert => {
           "stats.decoder.event.icmpv6.unassigned_type" => "string"
         }
-        on_error => "stats_decoder_event_icmpv6_unassigned_type_conversion_error"
+        on_error => "icmpv6_unassigned_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_unassigned_type_labels.value" => "%{stats.decoder.event.icmpv6.unassigned_type}"
+          "stats_decoder_event_icmpv6_unassigned_type_labels.value" =>
+          "%{stats.decoder.event.icmpv6.unassigned_type}"
         }
         on_error => "stats_decoder_event_icmpv6_unassigned_type_not_found"
       }
-      if ![stats_decoder_event_icmpv6_unassigned_type_not_found] and [stats][decoder][event][icmpv6][unassigned_type] != "" {
+      if ![stats_decoder_event_icmpv6_unassigned_type_not_found]
+      and [stats][decoder][event][icmpv6][unassigned_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_unassigned_type_labels.key" => "stats_decoder_event_icmpv6_unassigned_type"
+            "stats_decoder_event_icmpv6_unassigned_type_labels.key" =>
+            "stats_decoder_event_icmpv6_unassigned_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_unassigned_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_unassigned_type_labels"
           }
         }
       }
@@ -28466,24 +33024,28 @@ filter {
         convert => {
           "stats.decoder.event.icmpv6.experimentation_type" => "string"
         }
-        on_error => "stats_decoder_event_icmpv6_experimentation_type_conversion_error"
+        on_error => "icmpv6_experimentation_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_icmpv6_experimentation_type_labels.value" => "%{stats.decoder.event.icmpv6.experimentation_type}"
+          "stats_decoder_event_icmpv6_experimentation_type_labels.value" =>
+          "%{stats.decoder.event.icmpv6.experimentation_type}"
         }
         on_error => "stats_decoder_event_icmpv6_experimentation_type_not_found"
       }
-      if ![stats_decoder_event_icmpv6_experimentation_type_not_found] and [stats][decoder][event][icmpv6][experimentation_type] != "" {
+      if ![stats_decoder_event_icmpv6_experimentation_type_not_found]
+      and [stats][decoder][event][icmpv6][experimentation_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_icmpv6_experimentation_type_labels.key" => "stats_decoder_event_icmpv6_experimentation_type"
+            "stats_decoder_event_icmpv6_experimentation_type_labels.key" =>
+            "stats_decoder_event_icmpv6_experimentation_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_icmpv6_experimentation_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_icmpv6_experimentation_type_labels"
           }
         }
       }
@@ -28497,19 +33059,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_pkt_too_small_labels.value" => "%{stats.decoder.event.ipv6.pkt_too_small}"
+          "stats_decoder_event_ipv6_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ipv6.pkt_too_small}"
         }
         on_error => "stats_decoder_event_ipv6_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ipv6_pkt_too_small_not_found] and [stats][decoder][event][ipv6][pkt_too_small] != "" {
+      if ![stats_decoder_event_ipv6_pkt_too_small_not_found]
+      and [stats][decoder][event][ipv6][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_pkt_too_small_labels.key" => "stats_decoder_event_ipv6_pkt_too_small"
+            "stats_decoder_event_ipv6_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ipv6_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_pkt_too_small_labels"
           }
         }
       }
@@ -28523,19 +33089,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_trunc_pkt_labels.value" => "%{stats.decoder.event.ipv6.trunc_pkt}"
+          "stats_decoder_event_ipv6_trunc_pkt_labels.value" =>
+          "%{stats.decoder.event.ipv6.trunc_pkt}"
         }
         on_error => "stats_decoder_event_ipv6_trunc_pkt_not_found"
       }
-      if ![stats_decoder_event_ipv6_trunc_pkt_not_found] and [stats][decoder][event][ipv6][trunc_pkt] != "" {
+      if ![stats_decoder_event_ipv6_trunc_pkt_not_found]
+      and [stats][decoder][event][ipv6][trunc_pkt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_trunc_pkt_labels.key" => "stats_decoder_event_ipv6_trunc_pkt"
+            "stats_decoder_event_ipv6_trunc_pkt_labels.key" =>
+            "stats_decoder_event_ipv6_trunc_pkt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_trunc_pkt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_trunc_pkt_labels"
           }
         }
       }
@@ -28549,19 +33119,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_trunc_exthdr_labels.value" => "%{stats.decoder.event.ipv6.trunc_exthdr}"
+          "stats_decoder_event_ipv6_trunc_exthdr_labels.value" =>
+          "%{stats.decoder.event.ipv6.trunc_exthdr}"
         }
         on_error => "stats_decoder_event_ipv6_trunc_exthdr_not_found"
       }
-      if ![stats_decoder_event_ipv6_trunc_exthdr_not_found] and [stats][decoder][event][ipv6][trunc_exthdr] != "" {
+      if ![stats_decoder_event_ipv6_trunc_exthdr_not_found]
+      and [stats][decoder][event][ipv6][trunc_exthdr] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_trunc_exthdr_labels.key" => "stats_decoder_event_ipv6_trunc_exthdr"
+            "stats_decoder_event_ipv6_trunc_exthdr_labels.key" =>
+            "stats_decoder_event_ipv6_trunc_exthdr"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_trunc_exthdr_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_trunc_exthdr_labels"
           }
         }
       }
@@ -28575,19 +33149,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_fh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_fh}"
+          "stats_decoder_event_ipv6_exthdr_dupl_fh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_fh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_fh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_fh_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_fh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_fh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_fh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_fh_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_fh"
+            "stats_decoder_event_ipv6_exthdr_dupl_fh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_fh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_fh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_fh_labels"
           }
         }
       }
@@ -28596,24 +33174,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.exthdr_useless_fh" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_exthdr_useless_fh_conversion_error"
+        on_error => "ipv6_exthdr_useless_fh_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_useless_fh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_useless_fh}"
+          "stats_decoder_event_ipv6_exthdr_useless_fh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_useless_fh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_useless_fh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_useless_fh_not_found] and [stats][decoder][event][ipv6][exthdr_useless_fh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_useless_fh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_useless_fh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_useless_fh_labels.key" => "stats_decoder_event_ipv6_exthdr_useless_fh"
+            "stats_decoder_event_ipv6_exthdr_useless_fh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_useless_fh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_useless_fh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_useless_fh_labels"
           }
         }
       }
@@ -28627,19 +33209,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_rh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_rh}"
+          "stats_decoder_event_ipv6_exthdr_dupl_rh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_rh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_rh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_rh_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_rh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_rh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_rh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_rh_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_rh"
+            "stats_decoder_event_ipv6_exthdr_dupl_rh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_rh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_rh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_rh_labels"
           }
         }
       }
@@ -28653,19 +33239,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_hh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_hh}"
+          "stats_decoder_event_ipv6_exthdr_dupl_hh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_hh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_hh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_hh_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_hh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_hh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_hh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_hh_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_hh"
+            "stats_decoder_event_ipv6_exthdr_dupl_hh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_hh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_hh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_hh_labels"
           }
         }
       }
@@ -28679,19 +33269,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_dh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_dh}"
+          "stats_decoder_event_ipv6_exthdr_dupl_dh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_dh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_dh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_dh_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_dh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_dh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_dh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_dh_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_dh"
+            "stats_decoder_event_ipv6_exthdr_dupl_dh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_dh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_dh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_dh_labels"
           }
         }
       }
@@ -28705,19 +33299,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_ah_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_ah}"
+          "stats_decoder_event_ipv6_exthdr_dupl_ah_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_ah}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_ah_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_ah_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_ah] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_ah_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_ah] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_ah_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_ah"
+            "stats_decoder_event_ipv6_exthdr_dupl_ah_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_ah"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_ah_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_ah_labels"
           }
         }
       }
@@ -28731,19 +33329,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_dupl_eh_labels.value" => "%{stats.decoder.event.ipv6.exthdr_dupl_eh}"
+          "stats_decoder_event_ipv6_exthdr_dupl_eh_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_dupl_eh}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_dupl_eh_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_dupl_eh_not_found] and [stats][decoder][event][ipv6][exthdr_dupl_eh] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_dupl_eh_not_found]
+      and [stats][decoder][event][ipv6][exthdr_dupl_eh] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_dupl_eh_labels.key" => "stats_decoder_event_ipv6_exthdr_dupl_eh"
+            "stats_decoder_event_ipv6_exthdr_dupl_eh_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_eh"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_dupl_eh_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_dupl_eh_labels"
           }
         }
       }
@@ -28752,24 +33354,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.exthdr_invalid_optlen" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_exthdr_invalid_optlen_conversion_error"
+        on_error => "ipv6_exthdr_invalid_optlen_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels.value" => "%{stats.decoder.event.ipv6.exthdr_invalid_optlen}"
+          "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_invalid_optlen}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_invalid_optlen_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_invalid_optlen_not_found] and [stats][decoder][event][ipv6][exthdr_invalid_optlen] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_invalid_optlen_not_found]
+      and [stats][decoder][event][ipv6][exthdr_invalid_optlen] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels.key" => "stats_decoder_event_ipv6_exthdr_invalid_optlen"
+            "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_invalid_optlen"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_invalid_optlen_labels"
           }
         }
       }
@@ -28783,19 +33389,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_wrong_ip_version_labels.value" => "%{stats.decoder.event.ipv6.wrong_ip_version}"
+          "stats_decoder_event_ipv6_wrong_ip_version_labels.value" =>
+          "%{stats.decoder.event.ipv6.wrong_ip_version}"
         }
         on_error => "stats_decoder_event_ipv6_wrong_ip_version_not_found"
       }
-      if ![stats_decoder_event_ipv6_wrong_ip_version_not_found] and [stats][decoder][event][ipv6][wrong_ip_version] != "" {
+      if ![stats_decoder_event_ipv6_wrong_ip_version_not_found]
+      and [stats][decoder][event][ipv6][wrong_ip_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_wrong_ip_version_labels.key" => "stats_decoder_event_ipv6_wrong_ip_version"
+            "stats_decoder_event_ipv6_wrong_ip_version_labels.key" =>
+            "stats_decoder_event_ipv6_wrong_ip_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_wrong_ip_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_wrong_ip_version_labels"
           }
         }
       }
@@ -28804,24 +33414,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.exthdr_ah_res_not_null" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_exthdr_ah_res_not_null_conversion_error"
+        on_error => "ipv6_exthdr_ah_res_not_null_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels.value" => "%{stats.decoder.event.ipv6.exthdr_ah_res_not_null}"
+          "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels.value" =>
+          "%{stats.decoder.event.ipv6.exthdr_ah_res_not_null}"
         }
         on_error => "stats_decoder_event_ipv6_exthdr_ah_res_not_null_not_found"
       }
-      if ![stats_decoder_event_ipv6_exthdr_ah_res_not_null_not_found] and [stats][decoder][event][ipv6][exthdr_ah_res_not_null] != "" {
+      if ![stats_decoder_event_ipv6_exthdr_ah_res_not_null_not_found]
+      and [stats][decoder][event][ipv6][exthdr_ah_res_not_null] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels.key" => "stats_decoder_event_ipv6_exthdr_ah_res_not_null"
+            "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels.key" =>
+            "stats_decoder_event_ipv6_exthdr_ah_res_not_null"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_exthdr_ah_res_not_null_labels"
           }
         }
       }
@@ -28830,24 +33444,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.hopopts_unknown_opt" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_hopopts_unknown_opt_conversion_error"
+        on_error => "ipv6_hopopts_unknown_opt_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_hopopts_unknown_opt_labels.value" => "%{stats.decoder.event.ipv6.hopopts_unknown_opt}"
+          "stats_decoder_event_ipv6_hopopts_unknown_opt_labels.value" =>
+          "%{stats.decoder.event.ipv6.hopopts_unknown_opt}"
         }
         on_error => "stats_decoder_event_ipv6_hopopts_unknown_opt_not_found"
       }
-      if ![stats_decoder_event_ipv6_hopopts_unknown_opt_not_found] and [stats][decoder][event][ipv6][hopopts_unknown_opt] != "" {
+      if ![stats_decoder_event_ipv6_hopopts_unknown_opt_not_found]
+      and [stats][decoder][event][ipv6][hopopts_unknown_opt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_hopopts_unknown_opt_labels.key" => "stats_decoder_event_ipv6_hopopts_unknown_opt"
+            "stats_decoder_event_ipv6_hopopts_unknown_opt_labels.key" =>
+            "stats_decoder_event_ipv6_hopopts_unknown_opt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_hopopts_unknown_opt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_hopopts_unknown_opt_labels"
           }
         }
       }
@@ -28856,24 +33474,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.hopopts_only_padding" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_hopopts_only_padding_conversion_error"
+        on_error => "ipv6_hopopts_only_padding_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_hopopts_only_padding_labels.value" => "%{stats.decoder.event.ipv6.hopopts_only_padding}"
+          "stats_decoder_event_ipv6_hopopts_only_padding_labels.value" =>
+          "%{stats.decoder.event.ipv6.hopopts_only_padding}"
         }
         on_error => "stats_decoder_event_ipv6_hopopts_only_padding_not_found"
       }
-      if ![stats_decoder_event_ipv6_hopopts_only_padding_not_found] and [stats][decoder][event][ipv6][hopopts_only_padding] != "" {
+      if ![stats_decoder_event_ipv6_hopopts_only_padding_not_found]
+      and [stats][decoder][event][ipv6][hopopts_only_padding] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_hopopts_only_padding_labels.key" => "stats_decoder_event_ipv6_hopopts_only_padding"
+            "stats_decoder_event_ipv6_hopopts_only_padding_labels.key" =>
+            "stats_decoder_event_ipv6_hopopts_only_padding"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_hopopts_only_padding_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_hopopts_only_padding_labels"
           }
         }
       }
@@ -28882,24 +33504,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.dstopts_unknown_opt" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_dstopts_unknown_opt_conversion_error"
+        on_error => "ipv6_dstopts_unknown_opt_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_dstopts_unknown_opt_labels.value" => "%{stats.decoder.event.ipv6.dstopts_unknown_opt}"
+          "stats_decoder_event_ipv6_dstopts_unknown_opt_labels.value" =>
+          "%{stats.decoder.event.ipv6.dstopts_unknown_opt}"
         }
         on_error => "stats_decoder_event_ipv6_dstopts_unknown_opt_not_found"
       }
-      if ![stats_decoder_event_ipv6_dstopts_unknown_opt_not_found] and [stats][decoder][event][ipv6][dstopts_unknown_opt] != "" {
+      if ![stats_decoder_event_ipv6_dstopts_unknown_opt_not_found]
+      and [stats][decoder][event][ipv6][dstopts_unknown_opt] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_dstopts_unknown_opt_labels.key" => "stats_decoder_event_ipv6_dstopts_unknown_opt"
+            "stats_decoder_event_ipv6_dstopts_unknown_opt_labels.key" =>
+            "stats_decoder_event_ipv6_dstopts_unknown_opt"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_dstopts_unknown_opt_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_dstopts_unknown_opt_labels"
           }
         }
       }
@@ -28908,24 +33534,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.dstopts_only_padding" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_dstopts_only_padding_conversion_error"
+        on_error => "ipv6_dstopts_only_padding_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_dstopts_only_padding_labels.value" => "%{stats.decoder.event.ipv6.dstopts_only_padding}"
+          "stats_decoder_event_ipv6_dstopts_only_padding_labels.value" =>
+          "%{stats.decoder.event.ipv6.dstopts_only_padding}"
         }
         on_error => "stats_decoder_event_ipv6_dstopts_only_padding_not_found"
       }
-      if ![stats_decoder_event_ipv6_dstopts_only_padding_not_found] and [stats][decoder][event][ipv6][dstopts_only_padding] != "" {
+      if ![stats_decoder_event_ipv6_dstopts_only_padding_not_found]
+      and [stats][decoder][event][ipv6][dstopts_only_padding] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_dstopts_only_padding_labels.key" => "stats_decoder_event_ipv6_dstopts_only_padding"
+            "stats_decoder_event_ipv6_dstopts_only_padding_labels.key" =>
+            "stats_decoder_event_ipv6_dstopts_only_padding"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_dstopts_only_padding_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_dstopts_only_padding_labels"
           }
         }
       }
@@ -28939,19 +33569,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_rh_type_0_labels.value" => "%{stats.decoder.event.ipv6.rh_type_0}"
+          "stats_decoder_event_ipv6_rh_type_0_labels.value" =>
+          "%{stats.decoder.event.ipv6.rh_type_0}"
         }
         on_error => "stats_decoder_event_ipv6_rh_type_0_not_found"
       }
-      if ![stats_decoder_event_ipv6_rh_type_0_not_found] and [stats][decoder][event][ipv6][rh_type_0] != "" {
+      if ![stats_decoder_event_ipv6_rh_type_0_not_found]
+      and [stats][decoder][event][ipv6][rh_type_0] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_rh_type_0_labels.key" => "stats_decoder_event_ipv6_rh_type_0"
+            "stats_decoder_event_ipv6_rh_type_0_labels.key" =>
+            "stats_decoder_event_ipv6_rh_type_0"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_rh_type_0_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_rh_type_0_labels"
           }
         }
       }
@@ -28965,19 +33599,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_zero_len_padn_labels.value" => "%{stats.decoder.event.ipv6.zero_len_padn}"
+          "stats_decoder_event_ipv6_zero_len_padn_labels.value" =>
+          "%{stats.decoder.event.ipv6.zero_len_padn}"
         }
         on_error => "stats_decoder_event_ipv6_zero_len_padn_not_found"
       }
-      if ![stats_decoder_event_ipv6_zero_len_padn_not_found] and [stats][decoder][event][ipv6][zero_len_padn] != "" {
+      if ![stats_decoder_event_ipv6_zero_len_padn_not_found]
+      and [stats][decoder][event][ipv6][zero_len_padn] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_zero_len_padn_labels.key" => "stats_decoder_event_ipv6_zero_len_padn"
+            "stats_decoder_event_ipv6_zero_len_padn_labels.key" =>
+            "stats_decoder_event_ipv6_zero_len_padn"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_zero_len_padn_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_zero_len_padn_labels"
           }
         }
       }
@@ -28986,24 +33624,29 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.fh_non_zero_reserved_field" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_fh_non_zero_reserved_field_conversion_error"
+        on_error => "ipv6_fh_non_zero_reserved_field_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels.value" => "%{stats.decoder.event.ipv6.fh_non_zero_reserved_field}"
+          "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels.value" =>
+          "%{stats.decoder.event.ipv6.fh_non_zero_reserved_field}"
         }
-        on_error => "stats_decoder_event_ipv6_fh_non_zero_reserved_field_not_found"
+        on_error =>
+        "stats_decoder_event_ipv6_fh_non_zero_reserved_field_not_found"
       }
-      if ![stats_decoder_event_ipv6_fh_non_zero_reserved_field_not_found] and [stats][decoder][event][ipv6][fh_non_zero_reserved_field] != "" {
+      if ![stats_decoder_event_ipv6_fh_non_zero_reserved_field_not_found]
+      and [stats][decoder][event][ipv6][fh_non_zero_reserved_field] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels.key" => "stats_decoder_event_ipv6_fh_non_zero_reserved_field"
+            "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels.key" =>
+            "stats_decoder_event_ipv6_fh_non_zero_reserved_field"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_fh_non_zero_reserved_field_labels"
           }
         }
       }
@@ -29012,24 +33655,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.data_after_none_header" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_data_after_none_header_conversion_error"
+        on_error => "ipv6_data_after_none_header_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_data_after_none_header_labels.value" => "%{stats.decoder.event.ipv6.data_after_none_header}"
+          "stats_decoder_event_ipv6_data_after_none_header_labels.value" =>
+          "%{stats.decoder.event.ipv6.data_after_none_header}"
         }
         on_error => "stats_decoder_event_ipv6_data_after_none_header_not_found"
       }
-      if ![stats_decoder_event_ipv6_data_after_none_header_not_found] and [stats][decoder][event][ipv6][data_after_none_header] != "" {
+      if ![stats_decoder_event_ipv6_data_after_none_header_not_found]
+      and [stats][decoder][event][ipv6][data_after_none_header] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_data_after_none_header_labels.key" => "stats_decoder_event_ipv6_data_after_none_header"
+            "stats_decoder_event_ipv6_data_after_none_header_labels.key" =>
+            "stats_decoder_event_ipv6_data_after_none_header"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_data_after_none_header_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_data_after_none_header_labels"
           }
         }
       }
@@ -29038,24 +33685,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.unknown_next_header" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_unknown_next_header_conversion_error"
+        on_error => "ipv6_unknown_next_header_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_unknown_next_header_labels.value" => "%{stats.decoder.event.ipv6.unknown_next_header}"
+          "stats_decoder_event_ipv6_unknown_next_header_labels.value" =>
+          "%{stats.decoder.event.ipv6.unknown_next_header}"
         }
         on_error => "stats_decoder_event_ipv6_unknown_next_header_not_found"
       }
-      if ![stats_decoder_event_ipv6_unknown_next_header_not_found] and [stats][decoder][event][ipv6][unknown_next_header] != "" {
+      if ![stats_decoder_event_ipv6_unknown_next_header_not_found]
+      and [stats][decoder][event][ipv6][unknown_next_header] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_unknown_next_header_labels.key" => "stats_decoder_event_ipv6_unknown_next_header"
+            "stats_decoder_event_ipv6_unknown_next_header_labels.key" =>
+            "stats_decoder_event_ipv6_unknown_next_header"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_unknown_next_header_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_unknown_next_header_labels"
           }
         }
       }
@@ -29069,19 +33720,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_icmpv4_labels.value" => "%{stats.decoder.event.ipv6.icmpv4}"
+          "stats_decoder_event_ipv6_icmpv4_labels.value" =>
+          "%{stats.decoder.event.ipv6.icmpv4}"
         }
         on_error => "stats_decoder_event_ipv6_icmpv4_not_found"
       }
-      if ![stats_decoder_event_ipv6_icmpv4_not_found] and [stats][decoder][event][ipv6][icmpv4] != "" {
+      if ![stats_decoder_event_ipv6_icmpv4_not_found]
+      and [stats][decoder][event][ipv6][icmpv4] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_icmpv4_labels.key" => "stats_decoder_event_ipv6_icmpv4"
+            "stats_decoder_event_ipv6_icmpv4_labels.key" =>
+            "stats_decoder_event_ipv6_icmpv4"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_icmpv4_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_icmpv4_labels"
           }
         }
       }
@@ -29090,24 +33745,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.frag_pkt_too_large" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_frag_pkt_too_large_conversion_error"
+        on_error => "ipv6_frag_pkt_too_large_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_frag_pkt_too_large_labels.value" => "%{stats.decoder.event.ipv6.frag_pkt_too_large}"
+          "stats_decoder_event_ipv6_frag_pkt_too_large_labels.value" =>
+          "%{stats.decoder.event.ipv6.frag_pkt_too_large}"
         }
         on_error => "stats_decoder_event_ipv6_frag_pkt_too_large_not_found"
       }
-      if ![stats_decoder_event_ipv6_frag_pkt_too_large_not_found] and [stats][decoder][event][ipv6][frag_pkt_too_large] != "" {
+      if ![stats_decoder_event_ipv6_frag_pkt_too_large_not_found]
+      and [stats][decoder][event][ipv6][frag_pkt_too_large] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_frag_pkt_too_large_labels.key" => "stats_decoder_event_ipv6_frag_pkt_too_large"
+            "stats_decoder_event_ipv6_frag_pkt_too_large_labels.key" =>
+            "stats_decoder_event_ipv6_frag_pkt_too_large"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_frag_pkt_too_large_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_frag_pkt_too_large_labels"
           }
         }
       }
@@ -29121,19 +33780,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_frag_overlap_labels.value" => "%{stats.decoder.event.ipv6.frag_overlap}"
+          "stats_decoder_event_ipv6_frag_overlap_labels.value" =>
+          "%{stats.decoder.event.ipv6.frag_overlap}"
         }
         on_error => "stats_decoder_event_ipv6_frag_overlap_not_found"
       }
-      if ![stats_decoder_event_ipv6_frag_overlap_not_found] and [stats][decoder][event][ipv6][frag_overlap] != "" {
+      if ![stats_decoder_event_ipv6_frag_overlap_not_found]
+      and [stats][decoder][event][ipv6][frag_overlap] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_frag_overlap_labels.key" => "stats_decoder_event_ipv6_frag_overlap"
+            "stats_decoder_event_ipv6_frag_overlap_labels.key" =>
+            "stats_decoder_event_ipv6_frag_overlap"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_frag_overlap_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_frag_overlap_labels"
           }
         }
       }
@@ -29142,24 +33805,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.frag_invalid_length" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_frag_invalid_length_conversion_error"
+        on_error => "ipv6_frag_invalid_length_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_frag_invalid_length_labels.value" => "%{stats.decoder.event.ipv6.frag_invalid_length}"
+          "stats_decoder_event_ipv6_frag_invalid_length_labels.value" =>
+          "%{stats.decoder.event.ipv6.frag_invalid_length}"
         }
         on_error => "stats_decoder_event_ipv6_frag_invalid_length_not_found"
       }
-      if ![stats_decoder_event_ipv6_frag_invalid_length_not_found] and [stats][decoder][event][ipv6][frag_invalid_length] != "" {
+      if ![stats_decoder_event_ipv6_frag_invalid_length_not_found]
+      and [stats][decoder][event][ipv6][frag_invalid_length] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_frag_invalid_length_labels.key" => "stats_decoder_event_ipv6_frag_invalid_length"
+            "stats_decoder_event_ipv6_frag_invalid_length_labels.key" =>
+            "stats_decoder_event_ipv6_frag_invalid_length"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_frag_invalid_length_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_frag_invalid_length_labels"
           }
         }
       }
@@ -29173,19 +33840,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_frag_ignored_labels.value" => "%{stats.decoder.event.ipv6.frag_ignored}"
+          "stats_decoder_event_ipv6_frag_ignored_labels.value" =>
+          "%{stats.decoder.event.ipv6.frag_ignored}"
         }
         on_error => "stats_decoder_event_ipv6_frag_ignored_not_found"
       }
-      if ![stats_decoder_event_ipv6_frag_ignored_not_found] and [stats][decoder][event][ipv6][frag_ignored] != "" {
+      if ![stats_decoder_event_ipv6_frag_ignored_not_found]
+      and [stats][decoder][event][ipv6][frag_ignored] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_frag_ignored_labels.key" => "stats_decoder_event_ipv6_frag_ignored"
+            "stats_decoder_event_ipv6_frag_ignored_labels.key" =>
+            "stats_decoder_event_ipv6_frag_ignored"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_frag_ignored_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_frag_ignored_labels"
           }
         }
       }
@@ -29194,24 +33865,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.ipv4_in_ipv6_too_small" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_conversion_error"
+        on_error => "ipv6_ipv4_in_ipv6_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels.value" => "%{stats.decoder.event.ipv6.ipv4_in_ipv6_too_small}"
+          "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels.value" =>
+          "%{stats.decoder.event.ipv6.ipv4_in_ipv6_too_small}"
         }
         on_error => "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_not_found"
       }
-      if ![stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_not_found] and [stats][decoder][event][ipv6][ipv4_in_ipv6_too_small] != "" {
+      if ![stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_not_found]
+      and [stats][decoder][event][ipv6][ipv4_in_ipv6_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels.key" => "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small"
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels.key" =>
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_too_small_labels"
           }
         }
       }
@@ -29220,24 +33895,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.ipv4_in_ipv6_wrong_version" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_conversion_error"
+        on_error => "ipv6_ipv4_in_ipv6_wrong_version_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels.value" => "%{stats.decoder.event.ipv6.ipv4_in_ipv6_wrong_version}"
+          "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels.value" =>
+          "%{stats.decoder.event.ipv6.ipv4_in_ipv6_wrong_version}"
         }
-        on_error => "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_not_found"
+        on_error => "ipv6_ipv4_in_ipv6_wrong_version_not_found"
       }
-      if ![stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_not_found] and [stats][decoder][event][ipv6][ipv4_in_ipv6_wrong_version] != "" {
+      if ![ipv6_ipv4_in_ipv6_wrong_version_not_found]
+      and [stats][decoder][event][ipv6][ipv4_in_ipv6_wrong_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels.key" => "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version"
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels.key" =>
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_ipv4_in_ipv6_wrong_version_labels"
           }
         }
       }
@@ -29246,24 +33925,28 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.ipv6_in_ipv6_too_small" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_conversion_error"
+        on_error => "ipv6_ipv6_in_ipv6_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels.value" => "%{stats.decoder.event.ipv6.ipv6_in_ipv6_too_small}"
+          "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels.value" =>
+          "%{stats.decoder.event.ipv6.ipv6_in_ipv6_too_small}"
         }
         on_error => "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_not_found"
       }
-      if ![stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_not_found] and [stats][decoder][event][ipv6][ipv6_in_ipv6_too_small] != "" {
+      if ![stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_not_found]
+      and [stats][decoder][event][ipv6][ipv6_in_ipv6_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels.key" => "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small"
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels.key" =>
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_too_small_labels"
           }
         }
       }
@@ -29272,24 +33955,29 @@ filter {
         convert => {
           "stats.decoder.event.ipv6.ipv6_in_ipv6_wrong_version" => "string"
         }
-        on_error => "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_conversion_error"
+        on_error => "ipv6_ipv6_in_ipv6_wrong_version_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels.value" => "%{stats.decoder.event.ipv6.ipv6_in_ipv6_wrong_version}"
+          "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels.value" =>
+          "%{stats.decoder.event.ipv6.ipv6_in_ipv6_wrong_version}"
         }
-        on_error => "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_not_found"
+        on_error =>
+        "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_not_found"
       }
-      if ![stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_not_found] and [stats][decoder][event][ipv6][ipv6_in_ipv6_wrong_version] != "" {
+      if ![stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_not_found]
+      and [stats][decoder][event][ipv6][ipv6_in_ipv6_wrong_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels.key" => "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version"
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels.key" =>
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipv6_ipv6_in_ipv6_wrong_version_labels"
           }
         }
       }
@@ -29303,19 +33991,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_tcp_pkt_too_small_labels.value" => "%{stats.decoder.event.tcp.pkt_too_small}"
+          "stats_decoder_event_tcp_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.tcp.pkt_too_small}"
         }
         on_error => "stats_decoder_event_tcp_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_tcp_pkt_too_small_not_found] and [stats][decoder][event][tcp][pkt_too_small] != "" {
+      if ![stats_decoder_event_tcp_pkt_too_small_not_found]
+      and [stats][decoder][event][tcp][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_tcp_pkt_too_small_labels.key" => "stats_decoder_event_tcp_pkt_too_small"
+            "stats_decoder_event_tcp_pkt_too_small_labels.key" =>
+            "stats_decoder_event_tcp_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_tcp_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_tcp_pkt_too_small_labels"
           }
         }
       }
@@ -29329,19 +34021,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_tcp_hlen_too_small_labels.value" => "%{stats.decoder.event.tcp.hlen_too_small}"
+          "stats_decoder_event_tcp_hlen_too_small_labels.value" =>
+          "%{stats.decoder.event.tcp.hlen_too_small}"
         }
         on_error => "stats_decoder_event_tcp_hlen_too_small_not_found"
       }
-      if ![stats_decoder_event_tcp_hlen_too_small_not_found] and [stats][decoder][event][tcp][hlen_too_small] != "" {
+      if ![stats_decoder_event_tcp_hlen_too_small_not_found]
+      and [stats][decoder][event][tcp][hlen_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_tcp_hlen_too_small_labels.key" => "stats_decoder_event_tcp_hlen_too_small"
+            "stats_decoder_event_tcp_hlen_too_small_labels.key" =>
+            "stats_decoder_event_tcp_hlen_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_tcp_hlen_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_tcp_hlen_too_small_labels"
           }
         }
       }
@@ -29355,19 +34051,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_tcp_invalid_optlen_labels.value" => "%{stats.decoder.event.tcp.invalid_optlen}"
+          "stats_decoder_event_tcp_invalid_optlen_labels.value" =>
+          "%{stats.decoder.event.tcp.invalid_optlen}"
         }
         on_error => "stats_decoder_event_tcp_invalid_optlen_not_found"
       }
-      if ![stats_decoder_event_tcp_invalid_optlen_not_found] and [stats][decoder][event][tcp][invalid_optlen] != "" {
+      if ![stats_decoder_event_tcp_invalid_optlen_not_found]
+      and [stats][decoder][event][tcp][invalid_optlen] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_tcp_invalid_optlen_labels.key" => "stats_decoder_event_tcp_invalid_optlen"
+            "stats_decoder_event_tcp_invalid_optlen_labels.key" =>
+            "stats_decoder_event_tcp_invalid_optlen"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_tcp_invalid_optlen_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_tcp_invalid_optlen_labels"
           }
         }
       }
@@ -29381,19 +34081,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_tcp_opt_invalid_len_labels.value" => "%{stats.decoder.event.tcp.opt_invalid_len}"
+          "stats_decoder_event_tcp_opt_invalid_len_labels.value" =>
+          "%{stats.decoder.event.tcp.opt_invalid_len}"
         }
         on_error => "stats_decoder_event_tcp_opt_invalid_len_not_found"
       }
-      if ![stats_decoder_event_tcp_opt_invalid_len_not_found] and [stats][decoder][event][tcp][opt_invalid_len] != "" {
+      if ![stats_decoder_event_tcp_opt_invalid_len_not_found]
+      and [stats][decoder][event][tcp][opt_invalid_len] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_tcp_opt_invalid_len_labels.key" => "stats_decoder_event_tcp_opt_invalid_len"
+            "stats_decoder_event_tcp_opt_invalid_len_labels.key" =>
+            "stats_decoder_event_tcp_opt_invalid_len"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_tcp_opt_invalid_len_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_tcp_opt_invalid_len_labels"
           }
         }
       }
@@ -29407,19 +34111,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_tcp_opt_duplicate_labels.value" => "%{stats.decoder.event.tcp.opt_duplicate}"
+          "stats_decoder_event_tcp_opt_duplicate_labels.value" =>
+          "%{stats.decoder.event.tcp.opt_duplicate}"
         }
         on_error => "stats_decoder_event_tcp_opt_duplicate_not_found"
       }
-      if ![stats_decoder_event_tcp_opt_duplicate_not_found] and [stats][decoder][event][tcp][opt_duplicate] != "" {
+      if ![stats_decoder_event_tcp_opt_duplicate_not_found]
+      and [stats][decoder][event][tcp][opt_duplicate] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_tcp_opt_duplicate_labels.key" => "stats_decoder_event_tcp_opt_duplicate"
+            "stats_decoder_event_tcp_opt_duplicate_labels.key" =>
+            "stats_decoder_event_tcp_opt_duplicate"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_tcp_opt_duplicate_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_tcp_opt_duplicate_labels"
           }
         }
       }
@@ -29433,19 +34141,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_udp_pkt_too_small_labels.value" => "%{stats.decoder.event.udp.pkt_too_small}"
+          "stats_decoder_event_udp_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.udp.pkt_too_small}"
         }
         on_error => "stats_decoder_event_udp_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_udp_pkt_too_small_not_found] and [stats][decoder][event][udp][pkt_too_small] != "" {
+      if ![stats_decoder_event_udp_pkt_too_small_not_found]
+      and [stats][decoder][event][udp][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_udp_pkt_too_small_labels.key" => "stats_decoder_event_udp_pkt_too_small"
+            "stats_decoder_event_udp_pkt_too_small_labels.key" =>
+            "stats_decoder_event_udp_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_udp_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_udp_pkt_too_small_labels"
           }
         }
       }
@@ -29459,19 +34171,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_udp_hlen_too_small_labels.value" => "%{stats.decoder.event.udp.hlen_too_small}"
+          "stats_decoder_event_udp_hlen_too_small_labels.value" =>
+          "%{stats.decoder.event.udp.hlen_too_small}"
         }
         on_error => "stats_decoder_event_udp_hlen_too_small_not_found"
       }
-      if ![stats_decoder_event_udp_hlen_too_small_not_found] and [stats][decoder][event][udp][hlen_too_small] != "" {
+      if ![stats_decoder_event_udp_hlen_too_small_not_found]
+      and [stats][decoder][event][udp][hlen_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_udp_hlen_too_small_labels.key" => "stats_decoder_event_udp_hlen_too_small"
+            "stats_decoder_event_udp_hlen_too_small_labels.key" =>
+            "stats_decoder_event_udp_hlen_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_udp_hlen_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_udp_hlen_too_small_labels"
           }
         }
       }
@@ -29485,19 +34201,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_udp_hlen_invalid_labels.value" => "%{stats.decoder.event.udp.hlen_invalid}"
+          "stats_decoder_event_udp_hlen_invalid_labels.value" =>
+          "%{stats.decoder.event.udp.hlen_invalid}"
         }
         on_error => "stats_decoder_event_udp_hlen_invalid_not_found"
       }
-      if ![stats_decoder_event_udp_hlen_invalid_not_found] and [stats][decoder][event][udp][hlen_invalid] != "" {
+      if ![stats_decoder_event_udp_hlen_invalid_not_found]
+      and [stats][decoder][event][udp][hlen_invalid] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_udp_hlen_invalid_labels.key" => "stats_decoder_event_udp_hlen_invalid"
+            "stats_decoder_event_udp_hlen_invalid_labels.key" =>
+            "stats_decoder_event_udp_hlen_invalid"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_udp_hlen_invalid_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_udp_hlen_invalid_labels"
           }
         }
       }
@@ -29511,19 +34231,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_udp_len_invalid_labels.value" => "%{stats.decoder.event.udp.len_invalid}"
+          "stats_decoder_event_udp_len_invalid_labels.value" =>
+          "%{stats.decoder.event.udp.len_invalid}"
         }
         on_error => "stats_decoder_event_udp_len_invalid_not_found"
       }
-      if ![stats_decoder_event_udp_len_invalid_not_found] and [stats][decoder][event][udp][len_invalid] != "" {
+      if ![stats_decoder_event_udp_len_invalid_not_found]
+      and [stats][decoder][event][udp][len_invalid] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_udp_len_invalid_labels.key" => "stats_decoder_event_udp_len_invalid"
+            "stats_decoder_event_udp_len_invalid_labels.key" =>
+            "stats_decoder_event_udp_len_invalid"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_udp_len_invalid_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_udp_len_invalid_labels"
           }
         }
       }
@@ -29537,19 +34261,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_sll_pkt_too_small_labels.value" => "%{stats.decoder.event.sll.pkt_too_small}"
+          "stats_decoder_event_sll_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.sll.pkt_too_small}"
         }
         on_error => "stats_decoder_event_sll_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_sll_pkt_too_small_not_found] and [stats][decoder][event][sll][pkt_too_small] != "" {
+      if ![stats_decoder_event_sll_pkt_too_small_not_found]
+      and [stats][decoder][event][sll][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_sll_pkt_too_small_labels.key" => "stats_decoder_event_sll_pkt_too_small"
+            "stats_decoder_event_sll_pkt_too_small_labels.key" =>
+            "stats_decoder_event_sll_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_sll_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_sll_pkt_too_small_labels"
           }
         }
       }
@@ -29558,24 +34286,28 @@ filter {
         convert => {
           "stats.decoder.event.ethernet.pkt_too_small" => "string"
         }
-        on_error => "stats_decoder_event_ethernet_pkt_too_small_conversion_error"
+        on_error => "ethernet_pkt_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ethernet_pkt_too_small_labels.value" => "%{stats.decoder.event.ethernet.pkt_too_small}"
+          "stats_decoder_event_ethernet_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ethernet.pkt_too_small}"
         }
         on_error => "stats_decoder_event_ethernet_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ethernet_pkt_too_small_not_found] and [stats][decoder][event][ethernet][pkt_too_small] != "" {
+      if ![stats_decoder_event_ethernet_pkt_too_small_not_found]
+      and [stats][decoder][event][ethernet][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ethernet_pkt_too_small_labels.key" => "stats_decoder_event_ethernet_pkt_too_small"
+            "stats_decoder_event_ethernet_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ethernet_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ethernet_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ethernet_pkt_too_small_labels"
           }
         }
       }
@@ -29589,19 +34321,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_pkt_too_small_labels.value" => "%{stats.decoder.event.ppp.pkt_too_small}"
+          "stats_decoder_event_ppp_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ppp.pkt_too_small}"
         }
         on_error => "stats_decoder_event_ppp_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ppp_pkt_too_small_not_found] and [stats][decoder][event][ppp][pkt_too_small] != "" {
+      if ![stats_decoder_event_ppp_pkt_too_small_not_found]
+      and [stats][decoder][event][ppp][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_pkt_too_small_labels.key" => "stats_decoder_event_ppp_pkt_too_small"
+            "stats_decoder_event_ppp_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ppp_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_pkt_too_small_labels"
           }
         }
       }
@@ -29615,19 +34351,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_vju_pkt_too_small_labels.value" => "%{stats.decoder.event.ppp.vju_pkt_too_small}"
+          "stats_decoder_event_ppp_vju_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ppp.vju_pkt_too_small}"
         }
         on_error => "stats_decoder_event_ppp_vju_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ppp_vju_pkt_too_small_not_found] and [stats][decoder][event][ppp][vju_pkt_too_small] != "" {
+      if ![stats_decoder_event_ppp_vju_pkt_too_small_not_found]
+      and [stats][decoder][event][ppp][vju_pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_vju_pkt_too_small_labels.key" => "stats_decoder_event_ppp_vju_pkt_too_small"
+            "stats_decoder_event_ppp_vju_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ppp_vju_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_vju_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_vju_pkt_too_small_labels"
           }
         }
       }
@@ -29641,19 +34381,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_ip4_pkt_too_small_labels.value" => "%{stats.decoder.event.ppp.ip4_pkt_too_small}"
+          "stats_decoder_event_ppp_ip4_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ppp.ip4_pkt_too_small}"
         }
         on_error => "stats_decoder_event_ppp_ip4_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ppp_ip4_pkt_too_small_not_found] and [stats][decoder][event][ppp][ip4_pkt_too_small] != "" {
+      if ![stats_decoder_event_ppp_ip4_pkt_too_small_not_found]
+      and [stats][decoder][event][ppp][ip4_pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_ip4_pkt_too_small_labels.key" => "stats_decoder_event_ppp_ip4_pkt_too_small"
+            "stats_decoder_event_ppp_ip4_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ppp_ip4_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_ip4_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_ip4_pkt_too_small_labels"
           }
         }
       }
@@ -29667,19 +34411,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_ip6_pkt_too_small_labels.value" => "%{stats.decoder.event.ppp.ip6_pkt_too_small}"
+          "stats_decoder_event_ppp_ip6_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ppp.ip6_pkt_too_small}"
         }
         on_error => "stats_decoder_event_ppp_ip6_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ppp_ip6_pkt_too_small_not_found] and [stats][decoder][event][ppp][ip6_pkt_too_small] != "" {
+      if ![stats_decoder_event_ppp_ip6_pkt_too_small_not_found]
+      and [stats][decoder][event][ppp][ip6_pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_ip6_pkt_too_small_labels.key" => "stats_decoder_event_ppp_ip6_pkt_too_small"
+            "stats_decoder_event_ppp_ip6_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ppp_ip6_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_ip6_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_ip6_pkt_too_small_labels"
           }
         }
       }
@@ -29693,19 +34441,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_wrong_type_labels.value" => "%{stats.decoder.event.ppp.wrong_type}"
+          "stats_decoder_event_ppp_wrong_type_labels.value" =>
+          "%{stats.decoder.event.ppp.wrong_type}"
         }
         on_error => "stats_decoder_event_ppp_wrong_type_not_found"
       }
-      if ![stats_decoder_event_ppp_wrong_type_not_found] and [stats][decoder][event][ppp][wrong_type] != "" {
+      if ![stats_decoder_event_ppp_wrong_type_not_found]
+      and [stats][decoder][event][ppp][wrong_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_wrong_type_labels.key" => "stats_decoder_event_ppp_wrong_type"
+            "stats_decoder_event_ppp_wrong_type_labels.key" =>
+            "stats_decoder_event_ppp_wrong_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_wrong_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_wrong_type_labels"
           }
         }
       }
@@ -29719,19 +34471,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ppp_unsup_proto_labels.value" => "%{stats.decoder.event.ppp.unsup_proto}"
+          "stats_decoder_event_ppp_unsup_proto_labels.value" =>
+          "%{stats.decoder.event.ppp.unsup_proto}"
         }
         on_error => "stats_decoder_event_ppp_unsup_proto_not_found"
       }
-      if ![stats_decoder_event_ppp_unsup_proto_not_found] and [stats][decoder][event][ppp][unsup_proto] != "" {
+      if ![stats_decoder_event_ppp_unsup_proto_not_found]
+      and [stats][decoder][event][ppp][unsup_proto] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ppp_unsup_proto_labels.key" => "stats_decoder_event_ppp_unsup_proto"
+            "stats_decoder_event_ppp_unsup_proto_labels.key" =>
+            "stats_decoder_event_ppp_unsup_proto"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ppp_unsup_proto_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ppp_unsup_proto_labels"
           }
         }
       }
@@ -29745,19 +34501,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_pppoe_pkt_too_small_labels.value" => "%{stats.decoder.event.pppoe.pkt_too_small}"
+          "stats_decoder_event_pppoe_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.pppoe.pkt_too_small}"
         }
         on_error => "stats_decoder_event_pppoe_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_pppoe_pkt_too_small_not_found] and [stats][decoder][event][pppoe][pkt_too_small] != "" {
+      if ![stats_decoder_event_pppoe_pkt_too_small_not_found]
+      and [stats][decoder][event][pppoe][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_pppoe_pkt_too_small_labels.key" => "stats_decoder_event_pppoe_pkt_too_small"
+            "stats_decoder_event_pppoe_pkt_too_small_labels.key" =>
+            "stats_decoder_event_pppoe_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_pppoe_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_pppoe_pkt_too_small_labels"
           }
         }
       }
@@ -29771,19 +34531,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_pppoe_wrong_code_labels.value" => "%{stats.decoder.event.pppoe.wrong_code}"
+          "stats_decoder_event_pppoe_wrong_code_labels.value" =>
+          "%{stats.decoder.event.pppoe.wrong_code}"
         }
         on_error => "stats_decoder_event_pppoe_wrong_code_not_found"
       }
-      if ![stats_decoder_event_pppoe_wrong_code_not_found] and [stats][decoder][event][pppoe][wrong_code] != "" {
+      if ![stats_decoder_event_pppoe_wrong_code_not_found]
+      and [stats][decoder][event][pppoe][wrong_code] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_pppoe_wrong_code_labels.key" => "stats_decoder_event_pppoe_wrong_code"
+            "stats_decoder_event_pppoe_wrong_code_labels.key" =>
+            "stats_decoder_event_pppoe_wrong_code"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_pppoe_wrong_code_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_pppoe_wrong_code_labels"
           }
         }
       }
@@ -29797,19 +34561,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_pppoe_malformed_tags_labels.value" => "%{stats.decoder.event.pppoe.malformed_tags}"
+          "stats_decoder_event_pppoe_malformed_tags_labels.value" =>
+          "%{stats.decoder.event.pppoe.malformed_tags}"
         }
         on_error => "stats_decoder_event_pppoe_malformed_tags_not_found"
       }
-      if ![stats_decoder_event_pppoe_malformed_tags_not_found] and [stats][decoder][event][pppoe][malformed_tags] != "" {
+      if ![stats_decoder_event_pppoe_malformed_tags_not_found]
+      and [stats][decoder][event][pppoe][malformed_tags] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_pppoe_malformed_tags_labels.key" => "stats_decoder_event_pppoe_malformed_tags"
+            "stats_decoder_event_pppoe_malformed_tags_labels.key" =>
+            "stats_decoder_event_pppoe_malformed_tags"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_pppoe_malformed_tags_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_pppoe_malformed_tags_labels"
           }
         }
       }
@@ -29823,19 +34591,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_pkt_too_small_labels.value" => "%{stats.decoder.event.gre.pkt_too_small}"
+          "stats_decoder_event_gre_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.gre.pkt_too_small}"
         }
         on_error => "stats_decoder_event_gre_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_gre_pkt_too_small_not_found] and [stats][decoder][event][gre][pkt_too_small] != "" {
+      if ![stats_decoder_event_gre_pkt_too_small_not_found]
+      and [stats][decoder][event][gre][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_pkt_too_small_labels.key" => "stats_decoder_event_gre_pkt_too_small"
+            "stats_decoder_event_gre_pkt_too_small_labels.key" =>
+            "stats_decoder_event_gre_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_pkt_too_small_labels"
           }
         }
       }
@@ -29849,19 +34621,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_wrong_version_labels.value" => "%{stats.decoder.event.gre.wrong_version}"
+          "stats_decoder_event_gre_wrong_version_labels.value" =>
+          "%{stats.decoder.event.gre.wrong_version}"
         }
         on_error => "stats_decoder_event_gre_wrong_version_not_found"
       }
-      if ![stats_decoder_event_gre_wrong_version_not_found] and [stats][decoder][event][gre][wrong_version] != "" {
+      if ![stats_decoder_event_gre_wrong_version_not_found]
+      and [stats][decoder][event][gre][wrong_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_wrong_version_labels.key" => "stats_decoder_event_gre_wrong_version"
+            "stats_decoder_event_gre_wrong_version_labels.key" =>
+            "stats_decoder_event_gre_wrong_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_wrong_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_wrong_version_labels"
           }
         }
       }
@@ -29875,19 +34651,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version0_recur_labels.value" => "%{stats.decoder.event.gre.version0_recur}"
+          "stats_decoder_event_gre_version0_recur_labels.value" =>
+          "%{stats.decoder.event.gre.version0_recur}"
         }
         on_error => "stats_decoder_event_gre_version0_recur_not_found"
       }
-      if ![stats_decoder_event_gre_version0_recur_not_found] and [stats][decoder][event][gre][version0_recur] != "" {
+      if ![stats_decoder_event_gre_version0_recur_not_found]
+      and [stats][decoder][event][gre][version0_recur] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version0_recur_labels.key" => "stats_decoder_event_gre_version0_recur"
+            "stats_decoder_event_gre_version0_recur_labels.key" =>
+            "stats_decoder_event_gre_version0_recur"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version0_recur_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version0_recur_labels"
           }
         }
       }
@@ -29901,19 +34681,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version0_flags_labels.value" => "%{stats.decoder.event.gre.version0_flags}"
+          "stats_decoder_event_gre_version0_flags_labels.value" =>
+          "%{stats.decoder.event.gre.version0_flags}"
         }
         on_error => "stats_decoder_event_gre_version0_flags_not_found"
       }
-      if ![stats_decoder_event_gre_version0_flags_not_found] and [stats][decoder][event][gre][version0_flags] != "" {
+      if ![stats_decoder_event_gre_version0_flags_not_found]
+      and [stats][decoder][event][gre][version0_flags] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version0_flags_labels.key" => "stats_decoder_event_gre_version0_flags"
+            "stats_decoder_event_gre_version0_flags_labels.key" =>
+            "stats_decoder_event_gre_version0_flags"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version0_flags_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version0_flags_labels"
           }
         }
       }
@@ -29922,24 +34706,28 @@ filter {
         convert => {
           "stats.decoder.event.gre.version0_hdr_too_big" => "string"
         }
-        on_error => "stats_decoder_event_gre_version0_hdr_too_big_conversion_error"
+        on_error => "gre_version0_hdr_too_big_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version0_hdr_too_big_labels.value" => "%{stats.decoder.event.gre.version0_hdr_too_big}"
+          "stats_decoder_event_gre_version0_hdr_too_big_labels.value" => "
+          %{stats.decoder.event.gre.version0_hdr_too_big}"
         }
         on_error => "stats_decoder_event_gre_version0_hdr_too_big_not_found"
       }
-      if ![stats_decoder_event_gre_version0_hdr_too_big_not_found] and [stats][decoder][event][gre][version0_hdr_too_big] != "" {
+      if ![stats_decoder_event_gre_version0_hdr_too_big_not_found]
+      and [stats][decoder][event][gre][version0_hdr_too_big] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version0_hdr_too_big_labels.key" => "stats_decoder_event_gre_version0_hdr_too_big"
+            "stats_decoder_event_gre_version0_hdr_too_big_labels.key" =>
+            "stats_decoder_event_gre_version0_hdr_too_big"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version0_hdr_too_big_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version0_hdr_too_big_labels"
           }
         }
       }
@@ -29948,24 +34736,28 @@ filter {
         convert => {
           "stats.decoder.event.gre.version0_malformed_sre_hdr" => "string"
         }
-        on_error => "stats_decoder_event_gre_version0_malformed_sre_hdr_conversion_error"
+        on_error => "gre_version0_malformed_sre_hdr_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version0_malformed_sre_hdr_labels.value" => "%{stats.decoder.event.gre.version0_malformed_sre_hdr}"
+          "stats_decoder_event_gre_version0_malformed_sre_hdr_labels.value" =>
+          "%{stats.decoder.event.gre.version0_malformed_sre_hdr}"
         }
-        on_error => "stats_decoder_event_gre_version0_malformed_sre_hdr_not_found"
+        on_error => "gre_version0_malformed_sre_hdr_not_found"
       }
-      if ![stats_decoder_event_gre_version0_malformed_sre_hdr_not_found] and [stats][decoder][event][gre][version0_malformed_sre_hdr] != "" {
+      if ![gre_version0_malformed_sre_hdr_not_found]
+      and [stats][decoder][event][gre][version0_malformed_sre_hdr] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version0_malformed_sre_hdr_labels.key" => "stats_decoder_event_gre_version0_malformed_sre_hdr"
+            "stats_decoder_event_gre_version0_malformed_sre_hdr_labels.key" =>
+            "stats_decoder_event_gre_version0_malformed_sre_hdr"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version0_malformed_sre_hdr_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version0_malformed_sre_hdr_labels"
           }
         }
       }
@@ -29979,19 +34771,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_chksum_labels.value" => "%{stats.decoder.event.gre.version1_chksum}"
+          "stats_decoder_event_gre_version1_chksum_labels.value" =>
+          "%{stats.decoder.event.gre.version1_chksum}"
         }
         on_error => "stats_decoder_event_gre_version1_chksum_not_found"
       }
-      if ![stats_decoder_event_gre_version1_chksum_not_found] and [stats][decoder][event][gre][version1_chksum] != "" {
+      if ![stats_decoder_event_gre_version1_chksum_not_found]
+      and [stats][decoder][event][gre][version1_chksum] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_chksum_labels.key" => "stats_decoder_event_gre_version1_chksum"
+            "stats_decoder_event_gre_version1_chksum_labels.key" =>
+            "stats_decoder_event_gre_version1_chksum"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_chksum_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_chksum_labels"
           }
         }
       }
@@ -30005,19 +34801,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_route_labels.value" => "%{stats.decoder.event.gre.version1_route}"
+          "stats_decoder_event_gre_version1_route_labels.value" =>
+          "%{stats.decoder.event.gre.version1_route}"
         }
         on_error => "stats_decoder_event_gre_version1_route_not_found"
       }
-      if ![stats_decoder_event_gre_version1_route_not_found] and [stats][decoder][event][gre][version1_route] != "" {
+      if ![stats_decoder_event_gre_version1_route_not_found]
+      and [stats][decoder][event][gre][version1_route] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_route_labels.key" => "stats_decoder_event_gre_version1_route"
+            "stats_decoder_event_gre_version1_route_labels.key" =>
+            "stats_decoder_event_gre_version1_route"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_route_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_route_labels"
           }
         }
       }
@@ -30031,19 +34831,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_ssr_labels.value" => "%{stats.decoder.event.gre.version1_ssr}"
+          "stats_decoder_event_gre_version1_ssr_labels.value" =>
+          "%{stats.decoder.event.gre.version1_ssr}"
         }
         on_error => "stats_decoder_event_gre_version1_ssr_not_found"
       }
-      if ![stats_decoder_event_gre_version1_ssr_not_found] and [stats][decoder][event][gre][version1_ssr] != "" {
+      if ![stats_decoder_event_gre_version1_ssr_not_found]
+      and [stats][decoder][event][gre][version1_ssr] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_ssr_labels.key" => "stats_decoder_event_gre_version1_ssr"
+            "stats_decoder_event_gre_version1_ssr_labels.key" =>
+            "stats_decoder_event_gre_version1_ssr"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_ssr_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_ssr_labels"
           }
         }
       }
@@ -30057,19 +34861,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_recur_labels.value" => "%{stats.decoder.event.gre.version1_recur}"
+          "stats_decoder_event_gre_version1_recur_labels.value" =>
+          "%{stats.decoder.event.gre.version1_recur}"
         }
         on_error => "stats_decoder_event_gre_version1_recur_not_found"
       }
-      if ![stats_decoder_event_gre_version1_recur_not_found] and [stats][decoder][event][gre][version1_recur] != "" {
+      if ![stats_decoder_event_gre_version1_recur_not_found]
+      and [stats][decoder][event][gre][version1_recur] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_recur_labels.key" => "stats_decoder_event_gre_version1_recur"
+            "stats_decoder_event_gre_version1_recur_labels.key" =>
+            "stats_decoder_event_gre_version1_recur"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_recur_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_recur_labels"
           }
         }
       }
@@ -30083,19 +34891,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_flags_labels.value" => "%{stats.decoder.event.gre.version1_flags}"
+          "stats_decoder_event_gre_version1_flags_labels.value" =>
+          "%{stats.decoder.event.gre.version1_flags}"
         }
         on_error => "stats_decoder_event_gre_version1_flags_not_found"
       }
-      if ![stats_decoder_event_gre_version1_flags_not_found] and [stats][decoder][event][gre][version1_flags] != "" {
+      if ![stats_decoder_event_gre_version1_flags_not_found]
+      and [stats][decoder][event][gre][version1_flags] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_flags_labels.key" => "stats_decoder_event_gre_version1_flags"
+            "stats_decoder_event_gre_version1_flags_labels.key" =>
+            "stats_decoder_event_gre_version1_flags"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_flags_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_flags_labels"
           }
         }
       }
@@ -30109,19 +34921,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_no_key_labels.value" => "%{stats.decoder.event.gre.version1_no_key}"
+          "stats_decoder_event_gre_version1_no_key_labels.value" =>
+          "%{stats.decoder.event.gre.version1_no_key}"
         }
         on_error => "stats_decoder_event_gre_version1_no_key_not_found"
       }
-      if ![stats_decoder_event_gre_version1_no_key_not_found] and [stats][decoder][event][gre][version1_no_key] != "" {
+      if ![stats_decoder_event_gre_version1_no_key_not_found]
+      and [stats][decoder][event][gre][version1_no_key] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_no_key_labels.key" => "stats_decoder_event_gre_version1_no_key"
+            "stats_decoder_event_gre_version1_no_key_labels.key" =>
+            "stats_decoder_event_gre_version1_no_key"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_no_key_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_no_key_labels"
           }
         }
       }
@@ -30130,24 +34946,28 @@ filter {
         convert => {
           "stats.decoder.event.gre.version1_wrong_protocol" => "string"
         }
-        on_error => "stats_decoder_event_gre_version1_wrong_protocol_conversion_error"
+        on_error => "gre_version1_wrong_protocol_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_wrong_protocol_labels.value" => "%{stats.decoder.event.gre.version1_wrong_protocol}"
+          "stats_decoder_event_gre_version1_wrong_protocol_labels.value" =>
+          "%{stats.decoder.event.gre.version1_wrong_protocol}"
         }
         on_error => "stats_decoder_event_gre_version1_wrong_protocol_not_found"
       }
-      if ![stats_decoder_event_gre_version1_wrong_protocol_not_found] and [stats][decoder][event][gre][version1_wrong_protocol] != "" {
+      if ![stats_decoder_event_gre_version1_wrong_protocol_not_found]
+      and [stats][decoder][event][gre][version1_wrong_protocol] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_wrong_protocol_labels.key" => "stats_decoder_event_gre_version1_wrong_protocol"
+            "stats_decoder_event_gre_version1_wrong_protocol_labels.key" =>
+            "stats_decoder_event_gre_version1_wrong_protocol"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_wrong_protocol_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_wrong_protocol_labels"
           }
         }
       }
@@ -30156,24 +34976,28 @@ filter {
         convert => {
           "stats.decoder.event.gre.version1_malformed_sre_hdr" => "string"
         }
-        on_error => "stats_decoder_event_gre_version1_malformed_sre_hdr_conversion_error"
+        on_error => "gre_version1_malformed_sre_hdr_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_malformed_sre_hdr_labels.value" => "%{stats.decoder.event.gre.version1_malformed_sre_hdr}"
+          "stats_decoder_event_gre_version1_malformed_sre_hdr_labels.value" =>
+          "%{stats.decoder.event.gre.version1_malformed_sre_hdr}"
         }
-        on_error => "stats_decoder_event_gre_version1_malformed_sre_hdr_not_found"
+        on_error => "gre_version1_malformed_sre_hdr_not_found"
       }
-      if ![stats_decoder_event_gre_version1_malformed_sre_hdr_not_found] and [stats][decoder][event][gre][version1_malformed_sre_hdr] != "" {
+      if ![gre_version1_malformed_sre_hdr_not_found]
+      and [stats][decoder][event][gre][version1_malformed_sre_hdr] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_malformed_sre_hdr_labels.key" => "stats_decoder_event_gre_version1_malformed_sre_hdr"
+            "stats_decoder_event_gre_version1_malformed_sre_hdr_labels.key" =>
+            "stats_decoder_event_gre_version1_malformed_sre_hdr"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_malformed_sre_hdr_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_malformed_sre_hdr_labels"
           }
         }
       }
@@ -30182,24 +35006,28 @@ filter {
         convert => {
           "stats.decoder.event.gre.version1_hdr_too_big" => "string"
         }
-        on_error => "stats_decoder_event_gre_version1_hdr_too_big_conversion_error"
+        on_error => "gre_version1_hdr_too_big_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_gre_version1_hdr_too_big_labels.value" => "%{stats.decoder.event.gre.version1_hdr_too_big}"
+          "stats_decoder_event_gre_version1_hdr_too_big_labels.value" =>
+          "%{stats.decoder.event.gre.version1_hdr_too_big}"
         }
         on_error => "stats_decoder_event_gre_version1_hdr_too_big_not_found"
       }
-      if ![stats_decoder_event_gre_version1_hdr_too_big_not_found] and [stats][decoder][event][gre][version1_hdr_too_big] != "" {
+      if ![stats_decoder_event_gre_version1_hdr_too_big_not_found]
+      and [stats][decoder][event][gre][version1_hdr_too_big] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_gre_version1_hdr_too_big_labels.key" => "stats_decoder_event_gre_version1_hdr_too_big"
+            "stats_decoder_event_gre_version1_hdr_too_big_labels.key" =>
+            "stats_decoder_event_gre_version1_hdr_too_big"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_gre_version1_hdr_too_big_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_gre_version1_hdr_too_big_labels"
           }
         }
       }
@@ -30213,19 +35041,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_vlan_header_too_small_labels.value" => "%{stats.decoder.event.vlan.header_too_small}"
+          "stats_decoder_event_vlan_header_too_small_labels.value" =>
+          "%{stats.decoder.event.vlan.header_too_small}"
         }
         on_error => "stats_decoder_event_vlan_header_too_small_not_found"
       }
-      if ![stats_decoder_event_vlan_header_too_small_not_found] and [stats][decoder][event][vlan][header_too_small] != "" {
+      if ![stats_decoder_event_vlan_header_too_small_not_found]
+      and [stats][decoder][event][vlan][header_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vlan_header_too_small_labels.key" => "stats_decoder_event_vlan_header_too_small"
+            "stats_decoder_event_vlan_header_too_small_labels.key" =>
+            "stats_decoder_event_vlan_header_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vlan_header_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vlan_header_too_small_labels"
           }
         }
       }
@@ -30239,19 +35071,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_vlan_unknown_type_labels.value" => "%{stats.decoder.event.vlan.unknown_type}"
+          "stats_decoder_event_vlan_unknown_type_labels.value" =>
+          "%{stats.decoder.event.vlan.unknown_type}"
         }
         on_error => "stats_decoder_event_vlan_unknown_type_not_found"
       }
-      if ![stats_decoder_event_vlan_unknown_type_not_found] and [stats][decoder][event][vlan][unknown_type] != "" {
+      if ![stats_decoder_event_vlan_unknown_type_not_found]
+      and [stats][decoder][event][vlan][unknown_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vlan_unknown_type_labels.key" => "stats_decoder_event_vlan_unknown_type"
+            "stats_decoder_event_vlan_unknown_type_labels.key" =>
+            "stats_decoder_event_vlan_unknown_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vlan_unknown_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vlan_unknown_type_labels"
           }
         }
       }
@@ -30265,19 +35101,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_vlan_too_many_layers_labels.value" => "%{stats.decoder.event.vlan.too_many_layers}"
+          "stats_decoder_event_vlan_too_many_layers_labels.value" =>
+          "%{stats.decoder.event.vlan.too_many_layers}"
         }
         on_error => "stats_decoder_event_vlan_too_many_layers_not_found"
       }
-      if ![stats_decoder_event_vlan_too_many_layers_not_found] and [stats][decoder][event][vlan][too_many_layers] != "" {
+      if ![stats_decoder_event_vlan_too_many_layers_not_found]
+      and [stats][decoder][event][vlan][too_many_layers] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vlan_too_many_layers_labels.key" => "stats_decoder_event_vlan_too_many_layers"
+            "stats_decoder_event_vlan_too_many_layers_labels.key" =>
+            "stats_decoder_event_vlan_too_many_layers"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vlan_too_many_layers_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vlan_too_many_layers_labels"
           }
         }
       }
@@ -30286,24 +35126,28 @@ filter {
         convert => {
           "stats.decoder.event.ieee8021ah.header_too_small" => "string"
         }
-        on_error => "stats_decoder_event_ieee8021ah_header_too_small_conversion_error"
+        on_error => "ieee8021ah_header_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ieee8021ah_header_too_small_labels.value" => "%{stats.decoder.event.ieee8021ah.header_too_small}"
+          "stats_decoder_event_ieee8021ah_header_too_small_labels.value" =>
+          "%{stats.decoder.event.ieee8021ah.header_too_small}"
         }
         on_error => "stats_decoder_event_ieee8021ah_header_too_small_not_found"
       }
-      if ![stats_decoder_event_ieee8021ah_header_too_small_not_found] and [stats][decoder][event][ieee8021ah][header_too_small] != "" {
+      if ![stats_decoder_event_ieee8021ah_header_too_small_not_found]
+      and [stats][decoder][event][ieee8021ah][header_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ieee8021ah_header_too_small_labels.key" => "stats_decoder_event_ieee8021ah_header_too_small"
+            "stats_decoder_event_ieee8021ah_header_too_small_labels.key" =>
+            "stats_decoder_event_ieee8021ah_header_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ieee8021ah_header_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ieee8021ah_header_too_small_labels"
           }
         }
       }
@@ -30312,24 +35156,28 @@ filter {
         convert => {
           "stats.decoder.event.vntag.header_too_small" => "string"
         }
-        on_error => "stats_decoder_event_vntag_header_too_small_conversion_error"
+        on_error => "vntag_header_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_vntag_header_too_small_labels.value" => "%{stats.decoder.event.vntag.header_too_small}"
+          "stats_decoder_event_vntag_header_too_small_labels.value" =>
+          "%{stats.decoder.event.vntag.header_too_small}"
         }
         on_error => "stats_decoder_event_vntag_header_too_small_not_found"
       }
-      if ![stats_decoder_event_vntag_header_too_small_not_found] and [stats][decoder][event][vntag][header_too_small] != "" {
+      if ![stats_decoder_event_vntag_header_too_small_not_found]
+      and [stats][decoder][event][vntag][header_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vntag_header_too_small_labels.key" => "stats_decoder_event_vntag_header_too_small"
+            "stats_decoder_event_vntag_header_too_small_labels.key" =>
+            "stats_decoder_event_vntag_header_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vntag_header_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vntag_header_too_small_labels"
           }
         }
       }
@@ -30343,19 +35191,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_vntag_unknown_type_labels.value" => "%{stats.decoder.event.vntag.unknown_type}"
+          "stats_decoder_event_vntag_unknown_type_labels.value" =>
+          "%{stats.decoder.event.vntag.unknown_type}"
         }
         on_error => "stats_decoder_event_vntag_unknown_type_not_found"
       }
-      if ![stats_decoder_event_vntag_unknown_type_not_found] and [stats][decoder][event][vntag][unknown_type] != "" {
+      if ![stats_decoder_event_vntag_unknown_type_not_found]
+      and [stats][decoder][event][vntag][unknown_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vntag_unknown_type_labels.key" => "stats_decoder_event_vntag_unknown_type"
+            "stats_decoder_event_vntag_unknown_type_labels.key" =>
+            "stats_decoder_event_vntag_unknown_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vntag_unknown_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vntag_unknown_type_labels"
           }
         }
       }
@@ -30364,24 +35216,28 @@ filter {
         convert => {
           "stats.decoder.event.ipraw.invalid_ip_version" => "string"
         }
-        on_error => "stats_decoder_event_ipraw_invalid_ip_version_conversion_error"
+        on_error => "ipraw_invalid_ip_version_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ipraw_invalid_ip_version_labels.value" => "%{stats.decoder.event.ipraw.invalid_ip_version}"
+          "stats_decoder_event_ipraw_invalid_ip_version_labels.value" =>
+          "%{stats.decoder.event.ipraw.invalid_ip_version}"
         }
         on_error => "stats_decoder_event_ipraw_invalid_ip_version_not_found"
       }
-      if ![stats_decoder_event_ipraw_invalid_ip_version_not_found] and [stats][decoder][event][ipraw][invalid_ip_version] != "" {
+      if ![stats_decoder_event_ipraw_invalid_ip_version_not_found]
+      and [stats][decoder][event][ipraw][invalid_ip_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ipraw_invalid_ip_version_labels.key" => "stats_decoder_event_ipraw_invalid_ip_version"
+            "stats_decoder_event_ipraw_invalid_ip_version_labels.key" =>
+            "stats_decoder_event_ipraw_invalid_ip_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ipraw_invalid_ip_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ipraw_invalid_ip_version_labels"
           }
         }
       }
@@ -30395,19 +35251,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_ltnull_pkt_too_small_labels.value" => "%{stats.decoder.event.ltnull.pkt_too_small}"
+          "stats_decoder_event_ltnull_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.ltnull.pkt_too_small}"
         }
         on_error => "stats_decoder_event_ltnull_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_ltnull_pkt_too_small_not_found] and [stats][decoder][event][ltnull][pkt_too_small] != "" {
+      if ![stats_decoder_event_ltnull_pkt_too_small_not_found]
+      and [stats][decoder][event][ltnull][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ltnull_pkt_too_small_labels.key" => "stats_decoder_event_ltnull_pkt_too_small"
+            "stats_decoder_event_ltnull_pkt_too_small_labels.key" =>
+            "stats_decoder_event_ltnull_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ltnull_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ltnull_pkt_too_small_labels"
           }
         }
       }
@@ -30416,24 +35276,28 @@ filter {
         convert => {
           "stats.decoder.event.ltnull.unsupported_type" => "string"
         }
-        on_error => "stats_decoder_event_ltnull_unsupported_type_conversion_error"
+        on_error => "ltnull_unsupported_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_ltnull_unsupported_type_labels.value" => "%{stats.decoder.event.ltnull.unsupported_type}"
+          "stats_decoder_event_ltnull_unsupported_type_labels.value" =>
+          "%{stats.decoder.event.ltnull.unsupported_type}"
         }
         on_error => "stats_decoder_event_ltnull_unsupported_type_not_found"
       }
-      if ![stats_decoder_event_ltnull_unsupported_type_not_found] and [stats][decoder][event][ltnull][unsupported_type] != "" {
+      if ![stats_decoder_event_ltnull_unsupported_type_not_found]
+      and [stats][decoder][event][ltnull][unsupported_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_ltnull_unsupported_type_labels.key" => "stats_decoder_event_ltnull_unsupported_type"
+            "stats_decoder_event_ltnull_unsupported_type_labels.key" =>
+            "stats_decoder_event_ltnull_unsupported_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_ltnull_unsupported_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_ltnull_unsupported_type_labels"
           }
         }
       }
@@ -30447,19 +35311,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_sctp_pkt_too_small_labels.value" => "%{stats.decoder.event.sctp.pkt_too_small}"
+          "stats_decoder_event_sctp_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.sctp.pkt_too_small}"
         }
         on_error => "stats_decoder_event_sctp_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_sctp_pkt_too_small_not_found] and [stats][decoder][event][sctp][pkt_too_small] != "" {
+      if ![stats_decoder_event_sctp_pkt_too_small_not_found]
+      and [stats][decoder][event][sctp][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_sctp_pkt_too_small_labels.key" => "stats_decoder_event_sctp_pkt_too_small"
+            "stats_decoder_event_sctp_pkt_too_small_labels.key" =>
+            "stats_decoder_event_sctp_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_sctp_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_sctp_pkt_too_small_labels"
           }
         }
       }
@@ -30473,19 +35341,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_header_too_small_labels.value" => "%{stats.decoder.event.mpls.header_too_small}"
+          "stats_decoder_event_mpls_header_too_small_labels.value" =>
+          "%{stats.decoder.event.mpls.header_too_small}"
         }
         on_error => "stats_decoder_event_mpls_header_too_small_not_found"
       }
-      if ![stats_decoder_event_mpls_header_too_small_not_found] and [stats][decoder][event][mpls][header_too_small] != "" {
+      if ![stats_decoder_event_mpls_header_too_small_not_found]
+      and [stats][decoder][event][mpls][header_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_header_too_small_labels.key" => "stats_decoder_event_mpls_header_too_small"
+            "stats_decoder_event_mpls_header_too_small_labels.key" =>
+            "stats_decoder_event_mpls_header_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_header_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_header_too_small_labels"
           }
         }
       }
@@ -30499,19 +35371,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_pkt_too_small_labels.value" => "%{stats.decoder.event.mpls.pkt_too_small}"
+          "stats_decoder_event_mpls_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.mpls.pkt_too_small}"
         }
         on_error => "stats_decoder_event_mpls_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_mpls_pkt_too_small_not_found] and [stats][decoder][event][mpls][pkt_too_small] != "" {
+      if ![stats_decoder_event_mpls_pkt_too_small_not_found]
+      and [stats][decoder][event][mpls][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_pkt_too_small_labels.key" => "stats_decoder_event_mpls_pkt_too_small"
+            "stats_decoder_event_mpls_pkt_too_small_labels.key" =>
+            "stats_decoder_event_mpls_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_pkt_too_small_labels"
           }
         }
       }
@@ -30520,24 +35396,28 @@ filter {
         convert => {
           "stats.decoder.event.mpls.bad_label_router_alert" => "string"
         }
-        on_error => "stats_decoder_event_mpls_bad_label_router_alert_conversion_error"
+        on_error => "mpls_bad_label_router_alert_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_bad_label_router_alert_labels.value" => "%{stats.decoder.event.mpls.bad_label_router_alert}"
+          "stats_decoder_event_mpls_bad_label_router_alert_labels.value" =>
+          "%{stats.decoder.event.mpls.bad_label_router_alert}"
         }
         on_error => "stats_decoder_event_mpls_bad_label_router_alert_not_found"
       }
-      if ![stats_decoder_event_mpls_bad_label_router_alert_not_found] and [stats][decoder][event][mpls][bad_label_router_alert] != "" {
+      if ![stats_decoder_event_mpls_bad_label_router_alert_not_found]
+      and [stats][decoder][event][mpls][bad_label_router_alert] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_bad_label_router_alert_labels.key" => "stats_decoder_event_mpls_bad_label_router_alert"
+            "stats_decoder_event_mpls_bad_label_router_alert_labels.key" =>
+            "stats_decoder_event_mpls_bad_label_router_alert"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_bad_label_router_alert_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_bad_label_router_alert_labels"
           }
         }
       }
@@ -30546,24 +35426,28 @@ filter {
         convert => {
           "stats.decoder.event.mpls.bad_label_implicit_null" => "string"
         }
-        on_error => "stats_decoder_event_mpls_bad_label_implicit_null_conversion_error"
+        on_error => "mpls_bad_label_implicit_null_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_bad_label_implicit_null_labels.value" => "%{stats.decoder.event.mpls.bad_label_implicit_null}"
+          "stats_decoder_event_mpls_bad_label_implicit_null_labels.value" =>
+          "%{stats.decoder.event.mpls.bad_label_implicit_null}"
         }
         on_error => "stats_decoder_event_mpls_bad_label_implicit_null_not_found"
       }
-      if ![stats_decoder_event_mpls_bad_label_implicit_null_not_found] and [stats][decoder][event][mpls][bad_label_implicit_null] != "" {
+      if ![stats_decoder_event_mpls_bad_label_implicit_null_not_found]
+      and [stats][decoder][event][mpls][bad_label_implicit_null] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_bad_label_implicit_null_labels.key" => "stats_decoder_event_mpls_bad_label_implicit_null"
+            "stats_decoder_event_mpls_bad_label_implicit_null_labels.key" =>
+            "stats_decoder_event_mpls_bad_label_implicit_null"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_bad_label_implicit_null_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_bad_label_implicit_null_labels"
           }
         }
       }
@@ -30572,24 +35456,28 @@ filter {
         convert => {
           "stats.decoder.event.mpls.bad_label_reserved" => "string"
         }
-        on_error => "stats_decoder_event_mpls_bad_label_reserved_conversion_error"
+        on_error => "mpls_bad_label_reserved_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_bad_label_reserved_labels.value" => "%{stats.decoder.event.mpls.bad_label_reserved}"
+          "stats_decoder_event_mpls_bad_label_reserved_labels.value" =>
+          "%{stats.decoder.event.mpls.bad_label_reserved}"
         }
         on_error => "stats_decoder_event_mpls_bad_label_reserved_not_found"
       }
-      if ![stats_decoder_event_mpls_bad_label_reserved_not_found] and [stats][decoder][event][mpls][bad_label_reserved] != "" {
+      if ![stats_decoder_event_mpls_bad_label_reserved_not_found]
+      and [stats][decoder][event][mpls][bad_label_reserved] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_bad_label_reserved_labels.key" => "stats_decoder_event_mpls_bad_label_reserved"
+            "stats_decoder_event_mpls_bad_label_reserved_labels.key" =>
+            "stats_decoder_event_mpls_bad_label_reserved"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_bad_label_reserved_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_bad_label_reserved_labels"
           }
         }
       }
@@ -30598,24 +35486,28 @@ filter {
         convert => {
           "stats.decoder.event.mpls.unknown_payload_type" => "string"
         }
-        on_error => "stats_decoder_event_mpls_unknown_payload_type_conversion_error"
+        on_error => "mpls_unknown_payload_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_mpls_unknown_payload_type_labels.value" => "%{stats.decoder.event.mpls.unknown_payload_type}"
+          "stats_decoder_event_mpls_unknown_payload_type_labels.value" =>
+          "%{stats.decoder.event.mpls.unknown_payload_type}"
         }
         on_error => "stats_decoder_event_mpls_unknown_payload_type_not_found"
       }
-      if ![stats_decoder_event_mpls_unknown_payload_type_not_found] and [stats][decoder][event][mpls][unknown_payload_type] != "" {
+      if ![stats_decoder_event_mpls_unknown_payload_type_not_found]
+      and [stats][decoder][event][mpls][unknown_payload_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_mpls_unknown_payload_type_labels.key" => "stats_decoder_event_mpls_unknown_payload_type"
+            "stats_decoder_event_mpls_unknown_payload_type_labels.key" =>
+            "stats_decoder_event_mpls_unknown_payload_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_mpls_unknown_payload_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_mpls_unknown_payload_type_labels"
           }
         }
       }
@@ -30624,24 +35516,28 @@ filter {
         convert => {
           "stats.decoder.event.vxlan.unknown_payload_type" => "string"
         }
-        on_error => "stats_decoder_event_vxlan_unknown_payload_type_conversion_error"
+        on_error => "vxlan_unknown_payload_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_vxlan_unknown_payload_type_labels.value" => "%{stats.decoder.event.vxlan.unknown_payload_type}"
+          "stats_decoder_event_vxlan_unknown_payload_type_labels.value" =>
+          "%{stats.decoder.event.vxlan.unknown_payload_type}"
         }
         on_error => "stats_decoder_event_vxlan_unknown_payload_type_not_found"
       }
-      if ![stats_decoder_event_vxlan_unknown_payload_type_not_found] and [stats][decoder][event][vxlan][unknown_payload_type] != "" {
+      if ![stats_decoder_event_vxlan_unknown_payload_type_not_found]
+      and [stats][decoder][event][vxlan][unknown_payload_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_vxlan_unknown_payload_type_labels.key" => "stats_decoder_event_vxlan_unknown_payload_type"
+            "stats_decoder_event_vxlan_unknown_payload_type_labels.key" =>
+            "stats_decoder_event_vxlan_unknown_payload_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_vxlan_unknown_payload_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_vxlan_unknown_payload_type_labels"
           }
         }
       }
@@ -30650,24 +35546,28 @@ filter {
         convert => {
           "stats.decoder.event.geneve.unknown_payload_type" => "string"
         }
-        on_error => "stats_decoder_event_geneve_unknown_payload_type_conversion_error"
+        on_error => "geneve_unknown_payload_type_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_geneve_unknown_payload_type_labels.value" => "%{stats.decoder.event.geneve.unknown_payload_type}"
+          "stats_decoder_event_geneve_unknown_payload_type_labels.value" =>
+          "%{stats.decoder.event.geneve.unknown_payload_type}"
         }
         on_error => "stats_decoder_event_geneve_unknown_payload_type_not_found"
       }
-      if ![stats_decoder_event_geneve_unknown_payload_type_not_found] and [stats][decoder][event][geneve][unknown_payload_type] != "" {
+      if ![stats_decoder_event_geneve_unknown_payload_type_not_found]
+      and [stats][decoder][event][geneve][unknown_payload_type] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_geneve_unknown_payload_type_labels.key" => "stats_decoder_event_geneve_unknown_payload_type"
+            "stats_decoder_event_geneve_unknown_payload_type_labels.key" =>
+            "stats_decoder_event_geneve_unknown_payload_type"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_geneve_unknown_payload_type_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_geneve_unknown_payload_type_labels"
           }
         }
       }
@@ -30676,24 +35576,28 @@ filter {
         convert => {
           "stats.decoder.event.erspan.header_too_small" => "string"
         }
-        on_error => "stats_decoder_event_erspan_header_too_small_conversion_error"
+        on_error => "erspan_header_too_small_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_erspan_header_too_small_labels.value" => "%{stats.decoder.event.erspan.header_too_small}"
+          "stats_decoder_event_erspan_header_too_small_labels.value" =>
+          "%{stats.decoder.event.erspan.header_too_small}"
         }
         on_error => "stats_decoder_event_erspan_header_too_small_not_found"
       }
-      if ![stats_decoder_event_erspan_header_too_small_not_found] and [stats][decoder][event][erspan][header_too_small] != "" {
+      if ![stats_decoder_event_erspan_header_too_small_not_found]
+      and [stats][decoder][event][erspan][header_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_erspan_header_too_small_labels.key" => "stats_decoder_event_erspan_header_too_small"
+            "stats_decoder_event_erspan_header_too_small_labels.key" =>
+            "stats_decoder_event_erspan_header_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_erspan_header_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_erspan_header_too_small_labels"
           }
         }
       }
@@ -30702,24 +35606,28 @@ filter {
         convert => {
           "stats.decoder.event.erspan.unsupported_version" => "string"
         }
-        on_error => "stats_decoder_event_erspan_unsupported_version_conversion_error"
+        on_error => "erspan_unsupported_version_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_erspan_unsupported_version_labels.value" => "%{stats.decoder.event.erspan.unsupported_version}"
+          "stats_decoder_event_erspan_unsupported_version_labels.value" =>
+          "%{stats.decoder.event.erspan.unsupported_version}"
         }
         on_error => "stats_decoder_event_erspan_unsupported_version_not_found"
       }
-      if ![stats_decoder_event_erspan_unsupported_version_not_found] and [stats][decoder][event][erspan][unsupported_version] != "" {
+      if ![stats_decoder_event_erspan_unsupported_version_not_found]
+      and [stats][decoder][event][erspan][unsupported_version] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_erspan_unsupported_version_labels.key" => "stats_decoder_event_erspan_unsupported_version"
+            "stats_decoder_event_erspan_unsupported_version_labels.key" =>
+            "stats_decoder_event_erspan_unsupported_version"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_erspan_unsupported_version_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_erspan_unsupported_version_labels"
           }
         }
       }
@@ -30728,24 +35636,28 @@ filter {
         convert => {
           "stats.decoder.event.erspan.too_many_vlan_layers" => "string"
         }
-        on_error => "stats_decoder_event_erspan_too_many_vlan_layers_conversion_error"
+        on_error => "erspan_too_many_vlan_layers_conversion_error"
       }
 
       mutate {
         replace => {
-          "stats_decoder_event_erspan_too_many_vlan_layers_labels.value" => "%{stats.decoder.event.erspan.too_many_vlan_layers}"
+          "stats_decoder_event_erspan_too_many_vlan_layers_labels.value" =>
+          "%{stats.decoder.event.erspan.too_many_vlan_layers}"
         }
         on_error => "stats_decoder_event_erspan_too_many_vlan_layers_not_found"
       }
-      if ![stats_decoder_event_erspan_too_many_vlan_layers_not_found] and [stats][decoder][event][erspan][too_many_vlan_layers] != "" {
+      if ![stats_decoder_event_erspan_too_many_vlan_layers_not_found]
+      and [stats][decoder][event][erspan][too_many_vlan_layers] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_erspan_too_many_vlan_layers_labels.key" => "stats_decoder_event_erspan_too_many_vlan_layers"
+            "stats_decoder_event_erspan_too_many_vlan_layers_labels.key" =>
+            "stats_decoder_event_erspan_too_many_vlan_layers"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_erspan_too_many_vlan_layers_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_erspan_too_many_vlan_layers_labels"
           }
         }
       }
@@ -30759,19 +35671,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_dce_pkt_too_small_labels.value" => "%{stats.decoder.event.dce.pkt_too_small}"
+          "stats_decoder_event_dce_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.dce.pkt_too_small}"
         }
         on_error => "stats_decoder_event_dce_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_dce_pkt_too_small_not_found] and [stats][decoder][event][dce][pkt_too_small] != "" {
+      if ![stats_decoder_event_dce_pkt_too_small_not_found]
+      and [stats][decoder][event][dce][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_dce_pkt_too_small_labels.key" => "stats_decoder_event_dce_pkt_too_small"
+            "stats_decoder_event_dce_pkt_too_small_labels.key" =>
+            "stats_decoder_event_dce_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_dce_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_dce_pkt_too_small_labels"
           }
         }
       }
@@ -30785,19 +35701,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_event_chdlc_pkt_too_small_labels.value" => "%{stats.decoder.event.chdlc.pkt_too_small}"
+          "stats_decoder_event_chdlc_pkt_too_small_labels.value" =>
+          "%{stats.decoder.event.chdlc.pkt_too_small}"
         }
         on_error => "stats_decoder_event_chdlc_pkt_too_small_not_found"
       }
-      if ![stats_decoder_event_chdlc_pkt_too_small_not_found] and [stats][decoder][event][chdlc][pkt_too_small] != "" {
+      if ![stats_decoder_event_chdlc_pkt_too_small_not_found]
+      and [stats][decoder][event][chdlc][pkt_too_small] != "" {
         mutate {
           replace => {
-            "stats_decoder_event_chdlc_pkt_too_small_labels.key" => "stats_decoder_event_chdlc_pkt_too_small"
+            "stats_decoder_event_chdlc_pkt_too_small_labels.key" =>
+            "stats_decoder_event_chdlc_pkt_too_small"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_event_chdlc_pkt_too_small_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_event_chdlc_pkt_too_small_labels"
           }
         }
       }
@@ -30811,19 +35731,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_decoder_too_many_layers_labels.value" => "%{stats.decoder.too_many_layers}"
+          "stats_decoder_too_many_layers_labels.value" =>
+          "%{stats.decoder.too_many_layers}"
         }
         on_error => "stats_decoder_too_many_layers_not_found"
       }
-      if ![stats_decoder_too_many_layers_not_found] and [stats][decoder][too_many_layers] != "" {
+      if ![stats_decoder_too_many_layers_not_found]
+      and [stats][decoder][too_many_layers] != "" {
         mutate {
           replace => {
-            "stats_decoder_too_many_layers_labels.key" => "stats_decoder_too_many_layers"
+            "stats_decoder_too_many_layers_labels.key" =>
+            "stats_decoder_too_many_layers"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_decoder_too_many_layers_labels"
+            "suricata_stats_about.labels" =>
+            "stats_decoder_too_many_layers_labels"
           }
         }
       }
@@ -31019,11 +35943,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_get_used_eval_labels.value" => "%{stats.flow.get_used_eval}"
+          "stats_flow_get_used_eval_labels.value" =>
+          "%{stats.flow.get_used_eval}"
         }
         on_error => "stats_flow_get_used_eval_not_found"
       }
-      if ![stats_flow_get_used_eval_not_found] and [stats][flow][get_used_eval] != "" {
+      if ![stats_flow_get_used_eval_not_found] and
+      [stats][flow][get_used_eval] != "" {
         mutate {
           replace => {
             "stats_flow_get_used_eval_labels.key" => "stats_flow_get_used_eval"
@@ -31045,19 +35971,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_get_used_eval_reject_labels.value" => "%{stats.flow.get_used_eval_reject}"
+          "stats_flow_get_used_eval_reject_labels.value" =>
+          "%{stats.flow.get_used_eval_reject}"
         }
         on_error => "stats_flow_get_used_eval_reject_not_found"
       }
-      if ![stats_flow_get_used_eval_reject_not_found] and [stats][flow][get_used_eval_reject] != "" {
+      if ![stats_flow_get_used_eval_reject_not_found] and
+      [stats][flow][get_used_eval_reject] != "" {
         mutate {
           replace => {
-            "stats_flow_get_used_eval_reject_labels.key" => "stats_flow_get_used_eval_reject"
+            "stats_flow_get_used_eval_reject_labels.key" =>
+            "stats_flow_get_used_eval_reject"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_get_used_eval_reject_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_get_used_eval_reject_labels"
           }
         }
       }
@@ -31071,19 +36001,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_get_used_eval_busy_labels.value" => "%{stats.flow.get_used_eval_busy}"
+          "stats_flow_get_used_eval_busy_labels.value" =>
+          "%{stats.flow.get_used_eval_busy}"
         }
         on_error => "stats_flow_get_used_eval_busy_not_found"
       }
-      if ![stats_flow_get_used_eval_busy_not_found] and [stats][flow][get_used_eval_busy] != "" {
+      if ![stats_flow_get_used_eval_busy_not_found] and
+      [stats][flow][get_used_eval_busy] != "" {
         mutate {
           replace => {
-            "stats_flow_get_used_eval_busy_labels.key" => "stats_flow_get_used_eval_busy"
+            "stats_flow_get_used_eval_busy_labels.key" =>
+            "stats_flow_get_used_eval_busy"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_get_used_eval_busy_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_get_used_eval_busy_labels"
           }
         }
       }
@@ -31097,14 +36031,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_get_used_failed_labels.value" => "%{stats.flow.get_used_failed}"
+          "stats_flow_get_used_failed_labels.value" =>
+          "%{stats.flow.get_used_failed}"
         }
         on_error => "stats_flow_get_used_failed_not_found"
       }
-      if ![stats_flow_get_used_failed_not_found] and [stats][flow][get_used_failed] != "" {
+      if ![stats_flow_get_used_failed_not_found] and
+      [stats][flow][get_used_failed] != "" {
         mutate {
           replace => {
-            "stats_flow_get_used_failed_labels.key" => "stats_flow_get_used_failed"
+            "stats_flow_get_used_failed_labels.key" =>
+            "stats_flow_get_used_failed"
           }
         }
         mutate {
@@ -31123,19 +36060,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_spare_sync_avg_labels.value" => "%{stats.flow.wrk.spare_sync_avg}"
+          "stats_flow_wrk_spare_sync_avg_labels.value" =>
+          "%{stats.flow.wrk.spare_sync_avg}"
         }
         on_error => "stats_flow_wrk_spare_sync_avg_not_found"
       }
-      if ![stats_flow_wrk_spare_sync_avg_not_found] and [stats][flow][wrk][spare_sync_avg] != "" {
+      if ![stats_flow_wrk_spare_sync_avg_not_found] and
+      [stats][flow][wrk][spare_sync_avg] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_spare_sync_avg_labels.key" => "stats_flow_wrk_spare_sync_avg"
+            "stats_flow_wrk_spare_sync_avg_labels.key" =>
+            "stats_flow_wrk_spare_sync_avg"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_spare_sync_avg_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_spare_sync_avg_labels"
           }
         }
       }
@@ -31149,14 +36090,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_spare_sync_labels.value" => "%{stats.flow.wrk.spare_sync}"
+          "stats_flow_wrk_spare_sync_labels.value" =>
+          "%{stats.flow.wrk.spare_sync}"
         }
         on_error => "stats_flow_wrk_spare_sync_not_found"
       }
-      if ![stats_flow_wrk_spare_sync_not_found] and [stats][flow][wrk][spare_sync] != "" {
+      if ![stats_flow_wrk_spare_sync_not_found] and
+      [stats][flow][wrk][spare_sync] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_spare_sync_labels.key" => "stats_flow_wrk_spare_sync"
+            "stats_flow_wrk_spare_sync_labels.key" =>
+            "stats_flow_wrk_spare_sync"
           }
         }
         mutate {
@@ -31175,19 +36119,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_spare_sync_incomplete_labels.value" => "%{stats.flow.wrk.spare_sync_incomplete}"
+          "stats_flow_wrk_spare_sync_incomplete_labels.value" =>
+          "%{stats.flow.wrk.spare_sync_incomplete}"
         }
         on_error => "stats_flow_wrk_spare_sync_incomplete_not_found"
       }
-      if ![stats_flow_wrk_spare_sync_incomplete_not_found] and [stats][flow][wrk][spare_sync_incomplete] != "" {
+      if ![stats_flow_wrk_spare_sync_incomplete_not_found] and
+      [stats][flow][wrk][spare_sync_incomplete] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_spare_sync_incomplete_labels.key" => "stats_flow_wrk_spare_sync_incomplete"
+            "stats_flow_wrk_spare_sync_incomplete_labels.key" =>
+            "stats_flow_wrk_spare_sync_incomplete"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_spare_sync_incomplete_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_spare_sync_incomplete_labels"
           }
         }
       }
@@ -31201,19 +36149,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_spare_sync_empty_labels.value" => "%{stats.flow.wrk.spare_sync_empty}"
+          "stats_flow_wrk_spare_sync_empty_labels.value" =>
+          "%{stats.flow.wrk.spare_sync_empty}"
         }
         on_error => "stats_flow_wrk_spare_sync_empty_not_found"
       }
-      if ![stats_flow_wrk_spare_sync_empty_not_found] and [stats][flow][wrk][spare_sync_empty] != "" {
+      if ![stats_flow_wrk_spare_sync_empty_not_found] and
+      [stats][flow][wrk][spare_sync_empty] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_spare_sync_empty_labels.key" => "stats_flow_wrk_spare_sync_empty"
+            "stats_flow_wrk_spare_sync_empty_labels.key" =>
+            "stats_flow_wrk_spare_sync_empty"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_spare_sync_empty_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_spare_sync_empty_labels"
           }
         }
       }
@@ -31227,19 +36179,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_flows_evicted_needs_work_labels.value" => "%{stats.flow.wrk.flows_evicted_needs_work}"
+          "stats_flow_wrk_flows_evicted_needs_work_labels.value" =>
+          "%{stats.flow.wrk.flows_evicted_needs_work}"
         }
         on_error => "stats_flow_wrk_flows_evicted_needs_work_not_found"
       }
-      if ![stats_flow_wrk_flows_evicted_needs_work_not_found] and [stats][flow][wrk][flows_evicted_needs_work] != "" {
+      if ![stats_flow_wrk_flows_evicted_needs_work_not_found] and
+      [stats][flow][wrk][flows_evicted_needs_work] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_flows_evicted_needs_work_labels.key" => "stats_flow_wrk_flows_evicted_needs_work"
+            "stats_flow_wrk_flows_evicted_needs_work_labels.key" =>
+            "stats_flow_wrk_flows_evicted_needs_work"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_flows_evicted_needs_work_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_flows_evicted_needs_work_labels"
           }
         }
       }
@@ -31253,19 +36209,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_flows_evicted_pkt_inject_labels.value" => "%{stats.flow.wrk.flows_evicted_pkt_inject}"
+          "stats_flow_wrk_flows_evicted_pkt_inject_labels.value" =>
+          "%{stats.flow.wrk.flows_evicted_pkt_inject}"
         }
         on_error => "stats_flow_wrk_flows_evicted_pkt_inject_not_found"
       }
-      if ![stats_flow_wrk_flows_evicted_pkt_inject_not_found] and [stats][flow][wrk][flows_evicted_pkt_inject] != "" {
+      if ![stats_flow_wrk_flows_evicted_pkt_inject_not_found] and
+      [stats][flow][wrk][flows_evicted_pkt_inject] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_flows_evicted_pkt_inject_labels.key" => "stats_flow_wrk_flows_evicted_pkt_inject"
+            "stats_flow_wrk_flows_evicted_pkt_inject_labels.key" =>
+            "stats_flow_wrk_flows_evicted_pkt_inject"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_flows_evicted_pkt_inject_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_flows_evicted_pkt_inject_labels"
           }
         }
       }
@@ -31279,19 +36239,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_flows_evicted_labels.value" => "%{stats.flow.wrk.flows_evicted}"
+          "stats_flow_wrk_flows_evicted_labels.value" =>
+          "%{stats.flow.wrk.flows_evicted}"
         }
         on_error => "stats_flow_wrk_flows_evicted_not_found"
       }
-      if ![stats_flow_wrk_flows_evicted_not_found] and [stats][flow][wrk][flows_evicted] != "" {
+      if ![stats_flow_wrk_flows_evicted_not_found] and
+      [stats][flow][wrk][flows_evicted] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_flows_evicted_labels.key" => "stats_flow_wrk_flows_evicted"
+            "stats_flow_wrk_flows_evicted_labels.key" =>
+            "stats_flow_wrk_flows_evicted"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_flows_evicted_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_flows_evicted_labels"
           }
         }
       }
@@ -31305,19 +36269,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_wrk_flows_injected_labels.value" => "%{stats.flow.wrk.flows_injected}"
+          "stats_flow_wrk_flows_injected_labels.value" =>
+          "%{stats.flow.wrk.flows_injected}"
         }
         on_error => "stats_flow_wrk_flows_injected_not_found"
       }
-      if ![stats_flow_wrk_flows_injected_not_found] and [stats][flow][wrk][flows_injected] != "" {
+      if ![stats_flow_wrk_flows_injected_not_found] and
+      [stats][flow][wrk][flows_injected] != "" {
         mutate {
           replace => {
-            "stats_flow_wrk_flows_injected_labels.key" => "stats_flow_wrk_flows_injected"
+            "stats_flow_wrk_flows_injected_labels.key" =>
+            "stats_flow_wrk_flows_injected"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_wrk_flows_injected_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_wrk_flows_injected_labels"
           }
         }
       }
@@ -31331,19 +36299,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_full_hash_pass_labels.value" => "%{stats.flow.mgr.full_hash_pass}"
+          "stats_flow_mgr_full_hash_pass_labels.value" =>
+          "%{stats.flow.mgr.full_hash_pass}"
         }
         on_error => "stats_flow_mgr_full_hash_pass_not_found"
       }
-      if ![stats_flow_mgr_full_hash_pass_not_found] and [stats][flow][mgr][full_hash_pass] != "" {
+      if ![stats_flow_mgr_full_hash_pass_not_found] and
+      [stats][flow][mgr][full_hash_pass] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_full_hash_pass_labels.key" => "stats_flow_mgr_full_hash_pass"
+            "stats_flow_mgr_full_hash_pass_labels.key" =>
+            "stats_flow_mgr_full_hash_pass"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_full_hash_pass_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_full_hash_pass_labels"
           }
         }
       }
@@ -31357,19 +36329,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_closed_pruned_labels.value" => "%{stats.flow.mgr.closed_pruned}"
+          "stats_flow_mgr_closed_pruned_labels.value" =>
+          "%{stats.flow.mgr.closed_pruned}"
         }
         on_error => "stats_flow_mgr_closed_pruned_not_found"
       }
-      if ![stats_flow_mgr_closed_pruned_not_found] and [stats][flow][mgr][closed_pruned] != "" {
+      if ![stats_flow_mgr_closed_pruned_not_found] and
+      [stats][flow][mgr][closed_pruned] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_closed_pruned_labels.key" => "stats_flow_mgr_closed_pruned"
+            "stats_flow_mgr_closed_pruned_labels.key" =>
+            "stats_flow_mgr_closed_pruned"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_closed_pruned_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_closed_pruned_labels"
           }
         }
       }
@@ -31383,14 +36359,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_new_pruned_labels.value" => "%{stats.flow.mgr.new_pruned}"
+          "stats_flow_mgr_new_pruned_labels.value" =>
+          "%{stats.flow.mgr.new_pruned}"
         }
         on_error => "stats_flow_mgr_new_pruned_not_found"
       }
-      if ![stats_flow_mgr_new_pruned_not_found] and [stats][flow][mgr][new_pruned] != "" {
+      if ![stats_flow_mgr_new_pruned_not_found] and
+      [stats][flow][mgr][new_pruned] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_new_pruned_labels.key" => "stats_flow_mgr_new_pruned"
+            "stats_flow_mgr_new_pruned_labels.key" =>
+            "stats_flow_mgr_new_pruned"
           }
         }
         mutate {
@@ -31409,14 +36388,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_est_pruned_labels.value" => "%{stats.flow.mgr.est_pruned}"
+          "stats_flow_mgr_est_pruned_labels.value" =>
+          "%{stats.flow.mgr.est_pruned}"
         }
         on_error => "stats_flow_mgr_est_pruned_not_found"
       }
-      if ![stats_flow_mgr_est_pruned_not_found] and [stats][flow][mgr][est_pruned] != "" {
+      if ![stats_flow_mgr_est_pruned_not_found] and
+      [stats][flow][mgr][est_pruned] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_est_pruned_labels.key" => "stats_flow_mgr_est_pruned"
+            "stats_flow_mgr_est_pruned_labels.key" =>
+            "stats_flow_mgr_est_pruned"
           }
         }
         mutate {
@@ -31435,19 +36417,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_bypassed_pruned_labels.value" => "%{stats.flow.mgr.bypassed_pruned}"
+          "stats_flow_mgr_bypassed_pruned_labels.value" =>
+          "%{stats.flow.mgr.bypassed_pruned}"
         }
         on_error => "stats_flow_mgr_bypassed_pruned_not_found"
       }
-      if ![stats_flow_mgr_bypassed_pruned_not_found] and [stats][flow][mgr][bypassed_pruned] != "" {
+      if ![stats_flow_mgr_bypassed_pruned_not_found] and
+      [stats][flow][mgr][bypassed_pruned] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_bypassed_pruned_labels.key" => "stats_flow_mgr_bypassed_pruned"
+            "stats_flow_mgr_bypassed_pruned_labels.key" =>
+            "stats_flow_mgr_bypassed_pruned"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_bypassed_pruned_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_bypassed_pruned_labels"
           }
         }
       }
@@ -31461,14 +36447,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_rows_maxlen_labels.value" => "%{stats.flow.mgr.rows_maxlen}"
+          "stats_flow_mgr_rows_maxlen_labels.value" =>
+          "%{stats.flow.mgr.rows_maxlen}"
         }
         on_error => "stats_flow_mgr_rows_maxlen_not_found"
       }
-      if ![stats_flow_mgr_rows_maxlen_not_found] and [stats][flow][mgr][rows_maxlen] != "" {
+      if ![stats_flow_mgr_rows_maxlen_not_found] and
+      [stats][flow][mgr][rows_maxlen] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_rows_maxlen_labels.key" => "stats_flow_mgr_rows_maxlen"
+            "stats_flow_mgr_rows_maxlen_labels.key" =>
+            "stats_flow_mgr_rows_maxlen"
           }
         }
         mutate {
@@ -31487,19 +36476,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_checked_labels.value" => "%{stats.flow.mgr.flows_checked}"
+          "stats_flow_mgr_flows_checked_labels.value" =>
+          "%{stats.flow.mgr.flows_checked}"
         }
         on_error => "stats_flow_mgr_flows_checked_not_found"
       }
-      if ![stats_flow_mgr_flows_checked_not_found] and [stats][flow][mgr][flows_checked] != "" {
+      if ![stats_flow_mgr_flows_checked_not_found] and
+      [stats][flow][mgr][flows_checked] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_checked_labels.key" => "stats_flow_mgr_flows_checked"
+            "stats_flow_mgr_flows_checked_labels.key" =>
+            "stats_flow_mgr_flows_checked"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_checked_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_checked_labels"
           }
         }
       }
@@ -31513,19 +36506,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_notimeout_labels.value" => "%{stats.flow.mgr.flows_notimeout}"
+          "stats_flow_mgr_flows_notimeout_labels.value" =>
+          "%{stats.flow.mgr.flows_notimeout}"
         }
         on_error => "stats_flow_mgr_flows_notimeout_not_found"
       }
-      if ![stats_flow_mgr_flows_notimeout_not_found] and [stats][flow][mgr][flows_notimeout] != "" {
+      if ![stats_flow_mgr_flows_notimeout_not_found] and
+      [stats][flow][mgr][flows_notimeout] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_notimeout_labels.key" => "stats_flow_mgr_flows_notimeout"
+            "stats_flow_mgr_flows_notimeout_labels.key" =>
+            "stats_flow_mgr_flows_notimeout"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_notimeout_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_notimeout_labels"
           }
         }
       }
@@ -31539,19 +36536,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_timeout_labels.value" => "%{stats.flow.mgr.flows_timeout}"
+          "stats_flow_mgr_flows_timeout_labels.value" =>
+          "%{stats.flow.mgr.flows_timeout}"
         }
         on_error => "stats_flow_mgr_flows_timeout_not_found"
       }
-      if ![stats_flow_mgr_flows_timeout_not_found] and [stats][flow][mgr][flows_timeout] != "" {
+      if ![stats_flow_mgr_flows_timeout_not_found] and
+      [stats][flow][mgr][flows_timeout] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_timeout_labels.key" => "stats_flow_mgr_flows_timeout"
+            "stats_flow_mgr_flows_timeout_labels.key" =>
+            "stats_flow_mgr_flows_timeout"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_timeout_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_timeout_labels"
           }
         }
       }
@@ -31565,19 +36566,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_timeout_inuse_labels.value" => "%{stats.flow.mgr.flows_timeout_inuse}"
+          "stats_flow_mgr_flows_timeout_inuse_labels.value" =>
+          "%{stats.flow.mgr.flows_timeout_inuse}"
         }
         on_error => "stats_flow_mgr_flows_timeout_inuse_not_found"
       }
-      if ![stats_flow_mgr_flows_timeout_inuse_not_found] and [stats][flow][mgr][flows_timeout_inuse] != "" {
+      if ![stats_flow_mgr_flows_timeout_inuse_not_found] and
+      [stats][flow][mgr][flows_timeout_inuse] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_timeout_inuse_labels.key" => "stats_flow_mgr_flows_timeout_inuse"
+            "stats_flow_mgr_flows_timeout_inuse_labels.key" =>
+            "stats_flow_mgr_flows_timeout_inuse"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_timeout_inuse_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_timeout_inuse_labels"
           }
         }
       }
@@ -31591,19 +36596,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_evicted_labels.value" => "%{stats.flow.mgr.flows_evicted}"
+          "stats_flow_mgr_flows_evicted_labels.value" =>
+          "%{stats.flow.mgr.flows_evicted}"
         }
         on_error => "stats_flow_mgr_flows_evicted_not_found"
       }
-      if ![stats_flow_mgr_flows_evicted_not_found] and [stats][flow][mgr][flows_evicted] != "" {
+      if ![stats_flow_mgr_flows_evicted_not_found] and
+      [stats][flow][mgr][flows_evicted] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_evicted_labels.key" => "stats_flow_mgr_flows_evicted"
+            "stats_flow_mgr_flows_evicted_labels.key" =>
+            "stats_flow_mgr_flows_evicted"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_evicted_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_evicted_labels"
           }
         }
       }
@@ -31617,19 +36626,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_mgr_flows_evicted_needs_work_labels.value" => "%{stats.flow.mgr.flows_evicted_needs_work}"
+          "stats_flow_mgr_flows_evicted_needs_work_labels.value" =>
+          "%{stats.flow.mgr.flows_evicted_needs_work}"
         }
         on_error => "stats_flow_mgr_flows_evicted_needs_work_not_found"
       }
-      if ![stats_flow_mgr_flows_evicted_needs_work_not_found] and [stats][flow][mgr][flows_evicted_needs_work] != "" {
+      if ![stats_flow_mgr_flows_evicted_needs_work_not_found] and
+      [stats][flow][mgr][flows_evicted_needs_work] != "" {
         mutate {
           replace => {
-            "stats_flow_mgr_flows_evicted_needs_work_labels.key" => "stats_flow_mgr_flows_evicted_needs_work"
+            "stats_flow_mgr_flows_evicted_needs_work_labels.key" =>
+            "stats_flow_mgr_flows_evicted_needs_work"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_mgr_flows_evicted_needs_work_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_mgr_flows_evicted_needs_work_labels"
           }
         }
       }
@@ -31669,19 +36682,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_emerg_mode_entered_labels.value" => "%{stats.flow.emerg_mode_entered}"
+          "stats_flow_emerg_mode_entered_labels.value" =>
+          "%{stats.flow.emerg_mode_entered}"
         }
         on_error => "stats_flow_emerg_mode_entered_not_found"
       }
-      if ![stats_flow_emerg_mode_entered_not_found] and [stats][flow][emerg_mode_entered] != "" {
+      if ![stats_flow_emerg_mode_entered_not_found]
+      and [stats][flow][emerg_mode_entered] != "" {
         mutate {
           replace => {
-            "stats_flow_emerg_mode_entered_labels.key" => "stats_flow_emerg_mode_entered"
+            "stats_flow_emerg_mode_entered_labels.key" =>
+            "stats_flow_emerg_mode_entered"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_emerg_mode_entered_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_emerg_mode_entered_labels"
           }
         }
       }
@@ -31695,14 +36712,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_emerg_mode_over_labels.value" => "%{stats.flow.emerg_mode_over}"
+          "stats_flow_emerg_mode_over_labels.value" =>
+          "%{stats.flow.emerg_mode_over}"
         }
         on_error => "stats_flow_emerg_mode_over_not_found"
       }
-      if ![stats_flow_emerg_mode_over_not_found] and [stats][flow][emerg_mode_over] != "" {
+      if ![stats_flow_emerg_mode_over_not_found]
+      and [stats][flow][emerg_mode_over] != "" {
         mutate {
           replace => {
-            "stats_flow_emerg_mode_over_labels.key" => "stats_flow_emerg_mode_over"
+            "stats_flow_emerg_mode_over_labels.key" =>
+            "stats_flow_emerg_mode_over"
           }
         }
         mutate {
@@ -31747,19 +36767,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv4_fragments_labels.value" => "%{stats.defrag.ipv4.fragments}"
+          "stats_defrag_ipv4_fragments_labels.value" =>
+          "%{stats.defrag.ipv4.fragments}"
         }
         on_error => "stats_defrag_ipv4_fragments_not_found"
       }
-      if ![stats_defrag_ipv4_fragments_not_found] and [stats][defrag][ipv4][fragments] != "" {
+      if ![stats_defrag_ipv4_fragments_not_found]
+      and [stats][defrag][ipv4][fragments] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv4_fragments_labels.key" => "stats_defrag_ipv4_fragments"
+            "stats_defrag_ipv4_fragments_labels.key" =>
+            "stats_defrag_ipv4_fragments"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_defrag_ipv4_fragments_labels"
+            "suricata_stats_about.labels" =>
+            "stats_defrag_ipv4_fragments_labels"
           }
         }
       }
@@ -31773,19 +36797,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv4_reassembled_labels.value" => "%{stats.defrag.ipv4.reassembled}"
+          "stats_defrag_ipv4_reassembled_labels.value" =>
+          "%{stats.defrag.ipv4.reassembled}"
         }
         on_error => "stats_defrag_ipv4_reassembled_not_found"
       }
-      if ![stats_defrag_ipv4_reassembled_not_found] and [stats][defrag][ipv4][reassembled] != "" {
+      if ![stats_defrag_ipv4_reassembled_not_found]
+      and [stats][defrag][ipv4][reassembled] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv4_reassembled_labels.key" => "stats_defrag_ipv4_reassembled"
+            "stats_defrag_ipv4_reassembled_labels.key" =>
+            "stats_defrag_ipv4_reassembled"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_defrag_ipv4_reassembled_labels"
+            "suricata_stats_about.labels" =>
+            "stats_defrag_ipv4_reassembled_labels"
           }
         }
       }
@@ -31799,14 +36827,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv4_timeouts_labels.value" => "%{stats.defrag.ipv4.timeouts}"
+          "stats_defrag_ipv4_timeouts_labels.value" =>
+          "%{stats.defrag.ipv4.timeouts}"
         }
         on_error => "stats_defrag_ipv4_timeouts_not_found"
       }
-      if ![stats_defrag_ipv4_timeouts_not_found] and [stats][defrag][ipv4][timeouts] != "" {
+      if ![stats_defrag_ipv4_timeouts_not_found]
+      and [stats][defrag][ipv4][timeouts] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv4_timeouts_labels.key" => "stats_defrag_ipv4_timeouts"
+            "stats_defrag_ipv4_timeouts_labels.key" =>
+            "stats_defrag_ipv4_timeouts"
           }
         }
         mutate {
@@ -31825,19 +36856,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv6_fragments_labels.value" => "%{stats.defrag.ipv6.fragments}"
+          "stats_defrag_ipv6_fragments_labels.value" =>
+          "%{stats.defrag.ipv6.fragments}"
         }
         on_error => "stats_defrag_ipv6_fragments_not_found"
       }
-      if ![stats_defrag_ipv6_fragments_not_found] and [stats][defrag][ipv6][fragments] != "" {
+      if ![stats_defrag_ipv6_fragments_not_found]
+      and [stats][defrag][ipv6][fragments] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv6_fragments_labels.key" => "stats_defrag_ipv6_fragments"
+            "stats_defrag_ipv6_fragments_labels.key" =>
+            "stats_defrag_ipv6_fragments"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_defrag_ipv6_fragments_labels"
+            "suricata_stats_about.labels" =>
+            "stats_defrag_ipv6_fragments_labels"
           }
         }
       }
@@ -31851,19 +36886,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv6_reassembled_labels.value" => "%{stats.defrag.ipv6.reassembled}"
+          "stats_defrag_ipv6_reassembled_labels.value" =>
+          "%{stats.defrag.ipv6.reassembled}"
         }
         on_error => "stats_defrag_ipv6_reassembled_not_found"
       }
-      if ![stats_defrag_ipv6_reassembled_not_found] and [stats][defrag][ipv6][reassembled] != "" {
+      if ![stats_defrag_ipv6_reassembled_not_found]
+      and [stats][defrag][ipv6][reassembled] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv6_reassembled_labels.key" => "stats_defrag_ipv6_reassembled"
+            "stats_defrag_ipv6_reassembled_labels.key" =>
+            "stats_defrag_ipv6_reassembled"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_defrag_ipv6_reassembled_labels"
+            "suricata_stats_about.labels" =>
+            "stats_defrag_ipv6_reassembled_labels"
           }
         }
       }
@@ -31877,14 +36916,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_ipv6_timeouts_labels.value" => "%{stats.defrag.ipv6.timeouts}"
+          "stats_defrag_ipv6_timeouts_labels.value" =>
+          "%{stats.defrag.ipv6.timeouts}"
         }
         on_error => "stats_defrag_ipv6_timeouts_not_found"
       }
-      if ![stats_defrag_ipv6_timeouts_not_found] and [stats][defrag][ipv6][timeouts] != "" {
+      if ![stats_defrag_ipv6_timeouts_not_found]
+      and [stats][defrag][ipv6][timeouts] != "" {
         mutate {
           replace => {
-            "stats_defrag_ipv6_timeouts_labels.key" => "stats_defrag_ipv6_timeouts"
+            "stats_defrag_ipv6_timeouts_labels.key" =>
+            "stats_defrag_ipv6_timeouts"
           }
         }
         mutate {
@@ -31903,19 +36945,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_defrag_max_frag_hits_labels.value" => "%{stats.defrag.max_frag_hits}"
+          "stats_defrag_max_frag_hits_labels.value" =>
+          "%{stats.defrag.max_frag_hits}"
         }
         on_error => "stats_defrag_max_frag_hits_not_found"
       }
-      if ![stats_defrag_max_frag_hits_not_found] and [stats][defrag][max_frag_hits] != "" {
+      if ![stats_defrag_max_frag_hits_not_found]
+      and [stats][defrag][max_frag_hits] != "" {
         mutate {
           replace => {
-            "stats_defrag_max_frag_hits_labels.key" => "stats_defrag_max_frag_hits"
+            "stats_defrag_max_frag_hits_labels.key" =>
+            "stats_defrag_max_frag_hits"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_defrag_max_frag_hits_labels"
+            "suricata_stats_about.labels" =>
+            "stats_defrag_max_frag_hits_labels"
           }
         }
       }
@@ -31929,19 +36975,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_local_pkts_labels.value" => "%{stats.flow_bypassed.local_pkts}"
+          "stats_flow_bypassed_local_pkts_labels.value" =>
+          "%{stats.flow_bypassed.local_pkts}"
         }
         on_error => "stats_flow_bypassed_local_pkts_not_found"
       }
-      if ![stats_flow_bypassed_local_pkts_not_found] and [stats][flow_bypassed][local_pkts] != "" {
+      if ![stats_flow_bypassed_local_pkts_not_found]
+      and [stats][flow_bypassed][local_pkts] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_local_pkts_labels.key" => "stats_flow_bypassed_local_pkts"
+            "stats_flow_bypassed_local_pkts_labels.key" =>
+            "stats_flow_bypassed_local_pkts"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_bypassed_local_pkts_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_bypassed_local_pkts_labels"
           }
         }
       }
@@ -31955,19 +37005,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_local_bytes_labels.value" => "%{stats.flow_bypassed.local_bytes}"
+          "stats_flow_bypassed_local_bytes_labels.value" =>
+          "%{stats.flow_bypassed.local_bytes}"
         }
         on_error => "stats_flow_bypassed_local_bytes_not_found"
       }
-      if ![stats_flow_bypassed_local_bytes_not_found] and [stats][flow_bypassed][local_bytes] != "" {
+      if ![stats_flow_bypassed_local_bytes_not_found]
+      and [stats][flow_bypassed][local_bytes] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_local_bytes_labels.key" => "stats_flow_bypassed_local_bytes"
+            "stats_flow_bypassed_local_bytes_labels.key" =>
+            "stats_flow_bypassed_local_bytes"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_bypassed_local_bytes_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_bypassed_local_bytes_labels"
           }
         }
       }
@@ -31981,19 +37035,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_local_capture_pkts_labels.value" => "%{stats.flow_bypassed.local_capture_pkts}"
+          "stats_flow_bypassed_local_capture_pkts_labels.value" =>
+          "%{stats.flow_bypassed.local_capture_pkts}"
         }
         on_error => "stats_flow_bypassed_local_capture_pkts_not_found"
       }
-      if ![stats_flow_bypassed_local_capture_pkts_not_found] and [stats][flow_bypassed][local_capture_pkts] != "" {
+      if ![stats_flow_bypassed_local_capture_pkts_not_found]
+      and [stats][flow_bypassed][local_capture_pkts] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_local_capture_pkts_labels.key" => "stats_flow_bypassed_local_capture_pkts"
+            "stats_flow_bypassed_local_capture_pkts_labels.key" =>
+            "stats_flow_bypassed_local_capture_pkts"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_bypassed_local_capture_pkts_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_bypassed_local_capture_pkts_labels"
           }
         }
       }
@@ -32007,19 +37065,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_local_capture_bytes_labels.value" => "%{stats.flow_bypassed.local_capture_bytes}"
+          "stats_flow_bypassed_local_capture_bytes_labels.value" =>
+          "%{stats.flow_bypassed.local_capture_bytes}"
         }
         on_error => "stats_flow_bypassed_local_capture_bytes_not_found"
       }
-      if ![stats_flow_bypassed_local_capture_bytes_not_found] and [stats][flow_bypassed][local_capture_bytes] != "" {
+      if ![stats_flow_bypassed_local_capture_bytes_not_found]
+      and [stats][flow_bypassed][local_capture_bytes] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_local_capture_bytes_labels.key" => "stats_flow_bypassed_local_capture_bytes"
+            "stats_flow_bypassed_local_capture_bytes_labels.key" =>
+            "stats_flow_bypassed_local_capture_bytes"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_flow_bypassed_local_capture_bytes_labels"
+            "suricata_stats_about.labels" =>
+            "stats_flow_bypassed_local_capture_bytes_labels"
           }
         }
       }
@@ -32033,14 +37095,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_closed_labels.value" => "%{stats.flow_bypassed.closed}"
+          "stats_flow_bypassed_closed_labels.value" =>
+          "%{stats.flow_bypassed.closed}"
         }
         on_error => "stats_flow_bypassed_closed_not_found"
       }
-      if ![stats_flow_bypassed_closed_not_found] and [stats][flow_bypassed][closed] != "" {
+      if ![stats_flow_bypassed_closed_not_found]
+      and [stats][flow_bypassed][closed] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_closed_labels.key" => "stats_flow_bypassed_closed"
+            "stats_flow_bypassed_closed_labels.key" =>
+            "stats_flow_bypassed_closed"
           }
         }
         mutate {
@@ -32059,11 +37124,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_pkts_labels.value" => "%{stats.flow_bypassed.pkts}"
+          "stats_flow_bypassed_pkts_labels.value" =>
+          "%{stats.flow_bypassed.pkts}"
         }
         on_error => "stats_flow_bypassed_pkts_not_found"
       }
-      if ![stats_flow_bypassed_pkts_not_found] and [stats][flow_bypassed][pkts] != "" {
+      if ![stats_flow_bypassed_pkts_not_found]
+      and [stats][flow_bypassed][pkts] != "" {
         mutate {
           replace => {
             "stats_flow_bypassed_pkts_labels.key" => "stats_flow_bypassed_pkts"
@@ -32085,14 +37152,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_flow_bypassed_bytes_labels.value" => "%{stats.flow_bypassed.bytes}"
+          "stats_flow_bypassed_bytes_labels.value" =>
+          "%{stats.flow_bypassed.bytes}"
         }
         on_error => "stats_flow_bypassed_bytes_not_found"
       }
-      if ![stats_flow_bypassed_bytes_not_found] and [stats][flow_bypassed][bytes] != "" {
+      if ![stats_flow_bypassed_bytes_not_found]
+      and [stats][flow_bypassed][bytes] != "" {
         mutate {
           replace => {
-            "stats_flow_bypassed_bytes_labels.key" => "stats_flow_bypassed_bytes"
+            "stats_flow_bypassed_bytes_labels.key" =>
+            "stats_flow_bypassed_bytes"
           }
         }
         mutate {
@@ -32137,14 +37207,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_ssn_memcap_drop_labels.value" => "%{stats.tcp.ssn_memcap_drop}"
+          "stats_tcp_ssn_memcap_drop_labels.value" =>
+          "%{stats.tcp.ssn_memcap_drop}"
         }
         on_error => "stats_tcp_ssn_memcap_drop_not_found"
       }
-      if ![stats_tcp_ssn_memcap_drop_not_found] and [stats][tcp][ssn_memcap_drop] != "" {
+      if ![stats_tcp_ssn_memcap_drop_not_found]
+      and [stats][tcp][ssn_memcap_drop] != "" {
         mutate {
           replace => {
-            "stats_tcp_ssn_memcap_drop_labels.key" => "stats_tcp_ssn_memcap_drop"
+            "stats_tcp_ssn_memcap_drop_labels.key" =>
+            "stats_tcp_ssn_memcap_drop"
           }
         }
         mutate {
@@ -32193,7 +37266,8 @@ filter {
         }
         on_error => "stats_tcp_pseudo_failed_not_found"
       }
-      if ![stats_tcp_pseudo_failed_not_found] and [stats][tcp][pseudo_failed] != "" {
+      if ![stats_tcp_pseudo_failed_not_found]
+      and [stats][tcp][pseudo_failed] != "" {
         mutate {
           replace => {
             "stats_tcp_pseudo_failed_labels.key" => "stats_tcp_pseudo_failed"
@@ -32215,14 +37289,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_invalid_checksum_labels.value" => "%{stats.tcp.invalid_checksum}"
+          "stats_tcp_invalid_checksum_labels.value" =>
+          "%{stats.tcp.invalid_checksum}"
         }
         on_error => "stats_tcp_invalid_checksum_not_found"
       }
-      if ![stats_tcp_invalid_checksum_not_found] and [stats][tcp][invalid_checksum] != "" {
+      if ![stats_tcp_invalid_checksum_not_found]
+      and [stats][tcp][invalid_checksum] != "" {
         mutate {
           replace => {
-            "stats_tcp_invalid_checksum_labels.key" => "stats_tcp_invalid_checksum"
+            "stats_tcp_invalid_checksum_labels.key" =>
+            "stats_tcp_invalid_checksum"
           }
         }
         mutate {
@@ -32345,19 +37422,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_midstream_pickups_labels.value" => "%{stats.tcp.midstream_pickups}"
+          "stats_tcp_midstream_pickups_labels.value" =>
+          "%{stats.tcp.midstream_pickups}"
         }
         on_error => "stats_tcp_midstream_pickups_not_found"
       }
-      if ![stats_tcp_midstream_pickups_not_found] and [stats][tcp][midstream_pickups] != "" {
+      if ![stats_tcp_midstream_pickups_not_found]
+      and [stats][tcp][midstream_pickups] != "" {
         mutate {
           replace => {
-            "stats_tcp_midstream_pickups_labels.key" => "stats_tcp_midstream_pickups"
+            "stats_tcp_midstream_pickups_labels.key" =>
+            "stats_tcp_midstream_pickups"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_midstream_pickups_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_midstream_pickups_labels"
           }
         }
       }
@@ -32371,19 +37452,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_pkt_on_wrong_thread_labels.value" => "%{stats.tcp.pkt_on_wrong_thread}"
+          "stats_tcp_pkt_on_wrong_thread_labels.value" =>
+          "%{stats.tcp.pkt_on_wrong_thread}"
         }
         on_error => "stats_tcp_pkt_on_wrong_thread_not_found"
       }
-      if ![stats_tcp_pkt_on_wrong_thread_not_found] and [stats][tcp][pkt_on_wrong_thread] != "" {
+      if ![stats_tcp_pkt_on_wrong_thread_not_found]
+      and [stats][tcp][pkt_on_wrong_thread] != "" {
         mutate {
           replace => {
-            "stats_tcp_pkt_on_wrong_thread_labels.key" => "stats_tcp_pkt_on_wrong_thread"
+            "stats_tcp_pkt_on_wrong_thread_labels.key" =>
+            "stats_tcp_pkt_on_wrong_thread"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_pkt_on_wrong_thread_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_pkt_on_wrong_thread_labels"
           }
         }
       }
@@ -32397,19 +37482,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_segment_memcap_drop_labels.value" => "%{stats.tcp.segment_memcap_drop}"
+          "stats_tcp_segment_memcap_drop_labels.value" =>
+          "%{stats.tcp.segment_memcap_drop}"
         }
         on_error => "stats_tcp_segment_memcap_drop_not_found"
       }
-      if ![stats_tcp_segment_memcap_drop_not_found] and [stats][tcp][segment_memcap_drop] != "" {
+      if ![stats_tcp_segment_memcap_drop_not_found]
+      and [stats][tcp][segment_memcap_drop] != "" {
         mutate {
           replace => {
-            "stats_tcp_segment_memcap_drop_labels.key" => "stats_tcp_segment_memcap_drop"
+            "stats_tcp_segment_memcap_drop_labels.key" =>
+            "stats_tcp_segment_memcap_drop"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_segment_memcap_drop_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_segment_memcap_drop_labels"
           }
         }
       }
@@ -32423,19 +37512,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_stream_depth_reached_labels.value" => "%{stats.tcp.stream_depth_reached}"
+          "stats_tcp_stream_depth_reached_labels.value" =>
+          "%{stats.tcp.stream_depth_reached}"
         }
         on_error => "stats_tcp_stream_depth_reached_not_found"
       }
-      if ![stats_tcp_stream_depth_reached_not_found] and [stats][tcp][stream_depth_reached] != "" {
+      if ![stats_tcp_stream_depth_reached_not_found]
+      and [stats][tcp][stream_depth_reached] != "" {
         mutate {
           replace => {
-            "stats_tcp_stream_depth_reached_labels.key" => "stats_tcp_stream_depth_reached"
+            "stats_tcp_stream_depth_reached_labels.key" =>
+            "stats_tcp_stream_depth_reached"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_stream_depth_reached_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_stream_depth_reached_labels"
           }
         }
       }
@@ -32449,11 +37542,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_reassembly_gap_labels.value" => "%{stats.tcp.reassembly_gap}"
+          "stats_tcp_reassembly_gap_labels.value" =>
+          "%{stats.tcp.reassembly_gap}"
         }
         on_error => "stats_tcp_reassembly_gap_not_found"
       }
-      if ![stats_tcp_reassembly_gap_not_found] and [stats][tcp][reassembly_gap] != "" {
+      if ![stats_tcp_reassembly_gap_not_found]
+      and [stats][tcp][reassembly_gap] != "" {
         mutate {
           replace => {
             "stats_tcp_reassembly_gap_labels.key" => "stats_tcp_reassembly_gap"
@@ -32503,17 +37598,21 @@ filter {
         replace => {
           "stats_tcp_overlap_diff_data_labels.value" => "%{stats.tcp.overlap_diff_data}"
         }
-        on_error => "stats_tcp_overlap_diff_data_not_found"
+        on_error =>
+          "stats_tcp_overlap_diff_data_not_found"
       }
-      if ![stats_tcp_overlap_diff_data_not_found] and [stats][tcp][overlap_diff_data] != "" {
+      if ![stats_tcp_overlap_diff_data_not_found]
+      and [stats][tcp][overlap_diff_data] != "" {
         mutate {
           replace => {
-            "stats_tcp_overlap_diff_data_labels.key" => "stats_tcp_overlap_diff_data"
+            "stats_tcp_overlap_diff_data_labels.key" =>
+            "stats_tcp_overlap_diff_data"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_overlap_diff_data_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_overlap_diff_data_labels"
           }
         }
       }
@@ -32527,19 +37626,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_insert_data_normal_fail_labels.value" => "%{stats.tcp.insert_data_normal_fail}"
+          "stats_tcp_insert_data_normal_fail_labels.value" =>
+          "%{stats.tcp.insert_data_normal_fail}"
         }
         on_error => "stats_tcp_insert_data_normal_fail_not_found"
       }
-      if ![stats_tcp_insert_data_normal_fail_not_found] and [stats][tcp][insert_data_normal_fail] != "" {
+      if ![stats_tcp_insert_data_normal_fail_not_found]
+      and [stats][tcp][insert_data_normal_fail] != "" {
         mutate {
           replace => {
-            "stats_tcp_insert_data_normal_fail_labels.key" => "stats_tcp_insert_data_normal_fail"
+            "stats_tcp_insert_data_normal_fail_labels.key" =>
+            "stats_tcp_insert_data_normal_fail"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_insert_data_normal_fail_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_insert_data_normal_fail_labels"
           }
         }
       }
@@ -32553,19 +37656,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_insert_data_overlap_fail_labels.value" => "%{stats.tcp.insert_data_overlap_fail}"
+          "stats_tcp_insert_data_overlap_fail_labels.value" =>
+          "%{stats.tcp.insert_data_overlap_fail}"
         }
         on_error => "stats_tcp_insert_data_overlap_fail_not_found"
       }
-      if ![stats_tcp_insert_data_overlap_fail_not_found] and [stats][tcp][insert_data_overlap_fail] != "" {
+      if ![stats_tcp_insert_data_overlap_fail_not_found]
+      and [stats][tcp][insert_data_overlap_fail] != "" {
         mutate {
           replace => {
-            "stats_tcp_insert_data_overlap_fail_labels.key" => "stats_tcp_insert_data_overlap_fail"
+            "stats_tcp_insert_data_overlap_fail_labels.key" =>
+            "stats_tcp_insert_data_overlap_fail"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_insert_data_overlap_fail_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_insert_data_overlap_fail_labels"
           }
         }
       }
@@ -32579,14 +37686,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_insert_list_fail_labels.value" => "%{stats.tcp.insert_list_fail}"
+          "stats_tcp_insert_list_fail_labels.value" =>
+          "%{stats.tcp.insert_list_fail}"
         }
         on_error => "stats_tcp_insert_list_fail_not_found"
       }
-      if ![stats_tcp_insert_list_fail_not_found] and [stats][tcp][insert_list_fail] != "" {
+      if ![stats_tcp_insert_list_fail_not_found]
+      and [stats][tcp][insert_list_fail] != "" {
         mutate {
           replace => {
-            "stats_tcp_insert_list_fail_labels.key" => "stats_tcp_insert_list_fail"
+            "stats_tcp_insert_list_fail_labels.key" =>
+            "stats_tcp_insert_list_fail"
           }
         }
         mutate {
@@ -32631,19 +37741,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_tcp_reassembly_memuse_labels.value" => "%{stats.tcp.reassembly_memuse}"
+          "stats_tcp_reassembly_memuse_labels.value" =>
+          "%{stats.tcp.reassembly_memuse}"
         }
         on_error => "stats_tcp_reassembly_memuse_not_found"
       }
-      if ![stats_tcp_reassembly_memuse_not_found] and [stats][tcp][reassembly_memuse] != "" {
+      if ![stats_tcp_reassembly_memuse_not_found]
+      and [stats][tcp][reassembly_memuse] != "" {
         mutate {
           replace => {
-            "stats_tcp_reassembly_memuse_labels.key" => "stats_tcp_reassembly_memuse"
+            "stats_tcp_reassembly_memuse_labels.key" =>
+            "stats_tcp_reassembly_memuse"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_tcp_reassembly_memuse_labels"
+            "suricata_stats_about.labels" =>
+            "stats_tcp_reassembly_memuse_labels"
           }
         }
       }
@@ -32693,19 +37807,23 @@ filter {
 
         mutate {
           replace => {
-            "stats_detect_engines_last_reload_labels.value" => "%{engine.last_reload}"
+            "stats_detect_engines_last_reload_labels.value" =>
+          "%{engine.last_reload}"
           }
           on_error => "stats_detect_engines_last_reload_not_found"
         }
-        if ![stats_detect_engines_last_reload_not_found] and [engine][last_reload] != "" {
+        if ![stats_detect_engines_last_reload_not_found]
+      and [engine][last_reload] != "" {
           mutate {
             replace => {
-              "stats_detect_engines_last_reload_labels.key" => "stats_detect_engines_last_reload"
+              "stats_detect_engines_last_reload_labels.key" =>
+            "stats_detect_engines_last_reload"
             }
           }
           mutate {
             merge => {
-              "suricata_stats_about.labels" => "stats_detect_engines_last_reload_labels"
+              "suricata_stats_about.labels" =>
+            "stats_detect_engines_last_reload_labels"
             }
           }
         }
@@ -32719,19 +37837,23 @@ filter {
 
         mutate {
           replace => {
-            "stats_detect_engines_rules_loaded_labels.value" => "%{engine.rules_loaded}"
+            "stats_detect_engines_rules_loaded_labels.value" =>
+          "%{engine.rules_loaded}"
           }
           on_error => "stats_detect_engines_rules_loaded_not_found"
         }
-        if ![stats_detect_engines_rules_loaded_not_found] and [engine][rules_loaded] != "" {
+        if ![stats_detect_engines_rules_loaded_not_found]
+      and [engine][rules_loaded] != "" {
           mutate {
             replace => {
-              "stats_detect_engines_rules_loaded_labels.key" => "stats_detect_engines_rules_loaded"
+              "stats_detect_engines_rules_loaded_labels.key" =>
+            "stats_detect_engines_rules_loaded"
             }
           }
           mutate {
             merge => {
-              "suricata_stats_about.labels" => "stats_detect_engines_rules_loaded_labels"
+              "suricata_stats_about.labels" =>
+            "stats_detect_engines_rules_loaded_labels"
             }
           }
         }
@@ -32745,19 +37867,23 @@ filter {
 
         mutate {
           replace => {
-            "stats_detect_engines_rules_failed_labels.value" => "%{engine.rules_failed}"
+            "stats_detect_engines_rules_failed_labels.value" =>
+          "%{engine.rules_failed}"
           }
           on_error => "stats_detect_engines_rules_failed_not_found"
         }
-        if ![stats_detect_engines_rules_failed_not_found] and [engine][rules_failed] != "" {
+        if ![stats_detect_engines_rules_failed_not_found]
+      and [engine][rules_failed] != "" {
           mutate {
             replace => {
-              "stats_detect_engines_rules_failed_labels.key" => "stats_detect_engines_rules_failed"
+              "stats_detect_engines_rules_failed_labels.key" =>
+            "stats_detect_engines_rules_failed"
             }
           }
           mutate {
             merge => {
-              "suricata_stats_about.labels" => "stats_detect_engines_rules_failed_labels"
+              "suricata_stats_about.labels" =>
+            "stats_detect_engines_rules_failed_labels"
             }
           }
         }
@@ -32776,7 +37902,8 @@ filter {
         }
         on_error => "stats_detect_alert_not_found"
       }
-      if ![stats_detect_alert_not_found] and [stats][detect][alert] != "" {
+      if ![stats_detect_alert_not_found]
+      and [stats][detect][alert] != "" {
         mutate {
           replace => {
             "stats_detect_alert_labels.key" => "stats_detect_alert"
@@ -32798,19 +37925,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_detect_alert_queue_overflow_labels.value" => "%{stats.detect.alert_queue_overflow}"
+          "stats_detect_alert_queue_overflow_labels.value" =>
+          "%{stats.detect.alert_queue_overflow}"
         }
         on_error => "stats_detect_alert_queue_overflow_not_found"
       }
-      if ![stats_detect_alert_queue_overflow_not_found] and [stats][detect][alert_queue_overflow] != "" {
+      if ![stats_detect_alert_queue_overflow_not_found]
+      and [stats][detect][alert_queue_overflow] != "" {
         mutate {
           replace => {
-            "stats_detect_alert_queue_overflow_labels.key" => "stats_detect_alert_queue_overflow"
+            "stats_detect_alert_queue_overflow_labels.key" =>
+            "stats_detect_alert_queue_overflow"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_detect_alert_queue_overflow_labels"
+            "suricata_stats_about.labels" =>
+            "stats_detect_alert_queue_overflow_labels"
           }
         }
       }
@@ -32824,19 +37955,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_detect_alerts_suppressed_labels.value" => "%{stats.detect.alerts_suppressed}"
+          "stats_detect_alerts_suppressed_labels.value" =>
+          "%{stats.detect.alerts_suppressed}"
         }
         on_error => "stats_detect_alerts_suppressed_not_found"
       }
-      if ![stats_detect_alerts_suppressed_not_found] and [stats][detect][alerts_suppressed] != "" {
+      if ![stats_detect_alerts_suppressed_not_found]
+      and [stats][detect][alerts_suppressed] != "" {
         mutate {
           replace => {
-            "stats_detect_alerts_suppressed_labels.key" => "stats_detect_alerts_suppressed"
+            "stats_detect_alerts_suppressed_labels.key" =>
+            "stats_detect_alerts_suppressed"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_detect_alerts_suppressed_labels"
+            "suricata_stats_about.labels" =>
+            "stats_detect_alerts_suppressed_labels"
           }
         }
       }
@@ -32850,14 +37985,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_http_labels.value" => "%{stats.app_layer.flow.http}"
+          "stats_app_layer_flow_http_labels.value" =>
+          "%{stats.app_layer.flow.http}"
         }
         on_error => "stats_app_layer_flow_http_not_found"
       }
-      if ![stats_app_layer_flow_http_not_found] and [stats][app_layer][flow][http] != "" {
+      if ![stats_app_layer_flow_http_not_found]
+      and [stats][app_layer][flow][http] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_http_labels.key" => "stats_app_layer_flow_http"
+            "stats_app_layer_flow_http_labels.key" =>
+            "stats_app_layer_flow_http"
           }
         }
         mutate {
@@ -32876,19 +38014,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_ftp_labels.value" => "%{stats.app_layer.flow.ftp}"
+          "stats_app_layer_flow_ftp_labels.value" =>
+          "%{stats.app_layer.flow.ftp}"
         }
         on_error => "stats_app_layer_flow_ftp_not_found"
       }
-      if ![stats_app_layer_flow_ftp_not_found] and [stats][app_layer][flow][ftp] != "" {
+      if ![stats_app_layer_flow_ftp_not_found]
+      and [stats][app_layer][flow][ftp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_ftp_labels.key" => "stats_app_layer_flow_ftp"
+            "stats_app_layer_flow_ftp_labels.key" =>
+            "stats_app_layer_flow_ftp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_ftp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_ftp_labels"
           }
         }
       }
@@ -32902,14 +38044,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_smtp_labels.value" => "%{stats.app_layer.flow.smtp}"
+          "stats_app_layer_flow_smtp_labels.value" =>
+          "%{stats.app_layer.flow.smtp}"
         }
         on_error => "stats_app_layer_flow_smtp_not_found"
       }
-      if ![stats_app_layer_flow_smtp_not_found] and [stats][app_layer][flow][smtp] != "" {
+      if ![stats_app_layer_flow_smtp_not_found]
+      and [stats][app_layer][flow][smtp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_smtp_labels.key" => "stats_app_layer_flow_smtp"
+            "stats_app_layer_flow_smtp_labels.key" =>
+            "stats_app_layer_flow_smtp"
           }
         }
         mutate {
@@ -32928,11 +38073,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_tls_labels.value" => "%{stats.app_layer.flow.tls}"
+          "stats_app_layer_flow_tls_labels.value" =>
+          "%{stats.app_layer.flow.tls}"
         }
         on_error => "stats_app_layer_flow_tls_not_found"
       }
-      if ![stats_app_layer_flow_tls_not_found] and [stats][app_layer][flow][tls] != "" {
+      if ![stats_app_layer_flow_tls_not_found]
+      and [stats][app_layer][flow][tls] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_tls_labels.key" => "stats_app_layer_flow_tls"
@@ -32954,11 +38101,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_ssh_labels.value" => "%{stats.app_layer.flow.ssh}"
+          "stats_app_layer_flow_ssh_labels.value" =>
+          "%{stats.app_layer.flow.ssh}"
         }
         on_error => "stats_app_layer_flow_ssh_not_found"
       }
-      if ![stats_app_layer_flow_ssh_not_found] and [stats][app_layer][flow][ssh] != "" {
+      if ![stats_app_layer_flow_ssh_not_found]
+      and [stats][app_layer][flow][ssh] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_ssh_labels.key" => "stats_app_layer_flow_ssh"
@@ -32980,14 +38129,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_imap_labels.value" => "%{stats.app_layer.flow.imap}"
+          "stats_app_layer_flow_imap_labels.value" =>
+          "%{stats.app_layer.flow.imap}"
         }
         on_error => "stats_app_layer_flow_imap_not_found"
       }
-      if ![stats_app_layer_flow_imap_not_found] and [stats][app_layer][flow][imap] != "" {
+      if ![stats_app_layer_flow_imap_not_found]
+      and [stats][app_layer][flow][imap] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_imap_labels.key" => "stats_app_layer_flow_imap"
+            "stats_app_layer_flow_imap_labels.key" =>
+            "stats_app_layer_flow_imap"
           }
         }
         mutate {
@@ -33006,11 +38158,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_smb_labels.value" => "%{stats.app_layer.flow.smb}"
+          "stats_app_layer_flow_smb_labels.value" =>
+          "%{stats.app_layer.flow.smb}"
         }
         on_error => "stats_app_layer_flow_smb_not_found"
       }
-      if ![stats_app_layer_flow_smb_not_found] and [stats][app_layer][flow][smb] != "" {
+      if ![stats_app_layer_flow_smb_not_found]
+      and [stats][app_layer][flow][smb] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_smb_labels.key" => "stats_app_layer_flow_smb"
@@ -33032,19 +38186,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_dcerpc_tcp_labels.value" => "%{stats.app_layer.flow.dcerpc_tcp}"
+          "stats_app_layer_flow_dcerpc_tcp_labels.value" =>
+          "%{stats.app_layer.flow.dcerpc_tcp}"
         }
         on_error => "stats_app_layer_flow_dcerpc_tcp_not_found"
       }
-      if ![stats_app_layer_flow_dcerpc_tcp_not_found] and [stats][app_layer][flow][dcerpc_tcp] != "" {
+      if ![stats_app_layer_flow_dcerpc_tcp_not_found]
+      and [stats][app_layer][flow][dcerpc_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_dcerpc_tcp_labels.key" => "stats_app_layer_flow_dcerpc_tcp"
+            "stats_app_layer_flow_dcerpc_tcp_labels.key" =>
+            "stats_app_layer_flow_dcerpc_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_dcerpc_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_dcerpc_tcp_labels"
           }
         }
       }
@@ -33058,19 +38216,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_dns_tcp_labels.value" => "%{stats.app_layer.flow.dns_tcp}"
+          "stats_app_layer_flow_dns_tcp_labels.value" =>
+          "%{stats.app_layer.flow.dns_tcp}"
         }
         on_error => "stats_app_layer_flow_dns_tcp_not_found"
       }
-      if ![stats_app_layer_flow_dns_tcp_not_found] and [stats][app_layer][flow][dns_tcp] != "" {
+      if ![stats_app_layer_flow_dns_tcp_not_found]
+      and [stats][app_layer][flow][dns_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_dns_tcp_labels.key" => "stats_app_layer_flow_dns_tcp"
+            "stats_app_layer_flow_dns_tcp_labels.key" =>
+            "stats_app_layer_flow_dns_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_dns_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_dns_tcp_labels"
           }
         }
       }
@@ -33084,19 +38246,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_nfs_tcp_labels.value" => "%{stats.app_layer.flow.nfs_tcp}"
+          "stats_app_layer_flow_nfs_tcp_labels.value" =>
+          "%{stats.app_layer.flow.nfs_tcp}"
         }
         on_error => "stats_app_layer_flow_nfs_tcp_not_found"
       }
-      if ![stats_app_layer_flow_nfs_tcp_not_found] and [stats][app_layer][flow][nfs_tcp] != "" {
+      if ![stats_app_layer_flow_nfs_tcp_not_found]
+      and [stats][app_layer][flow][nfs_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_nfs_tcp_labels.key" => "stats_app_layer_flow_nfs_tcp"
+            "stats_app_layer_flow_nfs_tcp_labels.key" =>
+            "stats_app_layer_flow_nfs_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_nfs_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_nfs_tcp_labels"
           }
         }
       }
@@ -33110,11 +38276,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_ntp_labels.value" => "%{stats.app_layer.flow.ntp}"
+          "stats_app_layer_flow_ntp_labels.value" =>
+          "%{stats.app_layer.flow.ntp}"
         }
         on_error => "stats_app_layer_flow_ntp_not_found"
       }
-      if ![stats_app_layer_flow_ntp_not_found] and [stats][app_layer][flow][ntp] != "" {
+      if ![stats_app_layer_flow_ntp_not_found]
+      and [stats][app_layer][flow][ntp] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_ntp_labels.key" => "stats_app_layer_flow_ntp"
@@ -33136,19 +38304,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_ftp-data_labels.value" => "%{stats.app_layer.flow.ftp-data}"
+          "stats_app_layer_flow_ftp-data_labels.value" =>
+          "%{stats.app_layer.flow.ftp-data}"
         }
         on_error => "stats_app_layer_flow_ftp-data_not_found"
       }
-      if ![stats_app_layer_flow_ftp-data_not_found] and [stats][app_layer][flow][ftp-data] != "" {
+      if ![stats_app_layer_flow_ftp-data_not_found]
+      and [stats][app_layer][flow][ftp-data] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_ftp-data_labels.key" => "stats_app_layer_flow_ftp-data"
+            "stats_app_layer_flow_ftp-data_labels.key" =>
+            "stats_app_layer_flow_ftp-data"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_ftp-data_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_ftp-data_labels"
           }
         }
       }
@@ -33162,14 +38334,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_tftp_labels.value" => "%{stats.app_layer.flow.tftp}"
+          "stats_app_layer_flow_tftp_labels.value" =>
+          "%{stats.app_layer.flow.tftp}"
         }
         on_error => "stats_app_layer_flow_tftp_not_found"
       }
-      if ![stats_app_layer_flow_tftp_not_found] and [stats][app_layer][flow][tftp] != "" {
+      if ![stats_app_layer_flow_tftp_not_found]
+      and [stats][app_layer][flow][tftp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_tftp_labels.key" => "stats_app_layer_flow_tftp"
+            "stats_app_layer_flow_tftp_labels.key" =>
+            "stats_app_layer_flow_tftp"
           }
         }
         mutate {
@@ -33188,14 +38363,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_ikev2_labels.value" => "%{stats.app_layer.flow.ikev2}"
+          "stats_app_layer_flow_ikev2_labels.value" =>
+          "%{stats.app_layer.flow.ikev2}"
         }
         on_error => "stats_app_layer_flow_ikev2_not_found"
       }
-      if ![stats_app_layer_flow_ikev2_not_found] and [stats][app_layer][flow][ikev2] != "" {
+      if ![stats_app_layer_flow_ikev2_not_found]
+      and [stats][app_layer][flow][ikev2] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_ikev2_labels.key" => "stats_app_layer_flow_ikev2"
+            "stats_app_layer_flow_ikev2_labels.key" =>
+            "stats_app_layer_flow_ikev2"
           }
         }
         mutate {
@@ -33214,19 +38392,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_krb5_tcp_labels.value" => "%{stats.app_layer.flow.krb5_tcp}"
+          "stats_app_layer_flow_krb5_tcp_labels.value" =>
+          "%{stats.app_layer.flow.krb5_tcp}"
         }
         on_error => "stats_app_layer_flow_krb5_tcp_not_found"
       }
-      if ![stats_app_layer_flow_krb5_tcp_not_found] and [stats][app_layer][flow][krb5_tcp] != "" {
+      if ![stats_app_layer_flow_krb5_tcp_not_found]
+      and [stats][app_layer][flow][krb5_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_krb5_tcp_labels.key" => "stats_app_layer_flow_krb5_tcp"
+            "stats_app_layer_flow_krb5_tcp_labels.key" =>
+            "stats_app_layer_flow_krb5_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_krb5_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_krb5_tcp_labels"
           }
         }
       }
@@ -33240,14 +38422,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_dhcp_labels.value" => "%{stats.app_layer.flow.dhcp}"
+          "stats_app_layer_flow_dhcp_labels.value" =>
+          "%{stats.app_layer.flow.dhcp}"
         }
         on_error => "stats_app_layer_flow_dhcp_not_found"
       }
-      if ![stats_app_layer_flow_dhcp_not_found] and [stats][app_layer][flow][dhcp] != "" {
+      if ![stats_app_layer_flow_dhcp_not_found]
+      and [stats][app_layer][flow][dhcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_dhcp_labels.key" => "stats_app_layer_flow_dhcp"
+            "stats_app_layer_flow_dhcp_labels.key" =>
+            "stats_app_layer_flow_dhcp"
           }
         }
         mutate {
@@ -33266,11 +38451,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_rfb_labels.value" => "%{stats.app_layer.flow.rfb}"
+          "stats_app_layer_flow_rfb_labels.value" =>
+          "%{stats.app_layer.flow.rfb}"
         }
         on_error => "stats_app_layer_flow_rfb_not_found"
       }
-      if ![stats_app_layer_flow_rfb_not_found] and [stats][app_layer][flow][rfb] != "" {
+      if ![stats_app_layer_flow_rfb_not_found]
+      and [stats][app_layer][flow][rfb] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_rfb_labels.key" => "stats_app_layer_flow_rfb"
@@ -33292,11 +38479,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_rdp_labels.value" => "%{stats.app_layer.flow.rdp}"
+          "stats_app_layer_flow_rdp_labels.value" =>
+          "%{stats.app_layer.flow.rdp}"
         }
         on_error => "stats_app_layer_flow_rdp_not_found"
       }
-      if ![stats_app_layer_flow_rdp_not_found] and [stats][app_layer][flow][rdp] != "" {
+      if ![stats_app_layer_flow_rdp_not_found]
+      and [stats][app_layer][flow][rdp] != "" {
         mutate {
           replace => {
             "stats_app_layer_flow_rdp_labels.key" => "stats_app_layer_flow_rdp"
@@ -33318,19 +38507,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_failed_tcp_labels.value" => "%{stats.app_layer.flow.failed_tcp}"
+          "stats_app_layer_flow_failed_tcp_labels.value" =>
+          "%{stats.app_layer.flow.failed_tcp}"
         }
         on_error => "stats_app_layer_flow_failed_tcp_not_found"
       }
-      if ![stats_app_layer_flow_failed_tcp_not_found] and [stats][app_layer][flow][failed_tcp] != "" {
+      if ![stats_app_layer_flow_failed_tcp_not_found]
+      and [stats][app_layer][flow][failed_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_failed_tcp_labels.key" => "stats_app_layer_flow_failed_tcp"
+            "stats_app_layer_flow_failed_tcp_labels.key" =>
+            "stats_app_layer_flow_failed_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_failed_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_failed_tcp_labels"
           }
         }
       }
@@ -33344,19 +38537,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_dcerpc_udp_labels.value" => "%{stats.app_layer.flow.dcerpc_udp}"
+          "stats_app_layer_flow_dcerpc_udp_labels.value" =>
+          "%{stats.app_layer.flow.dcerpc_udp}"
         }
         on_error => "stats_app_layer_flow_dcerpc_udp_not_found"
       }
-      if ![stats_app_layer_flow_dcerpc_udp_not_found] and [stats][app_layer][flow][dcerpc_udp] != "" {
+      if ![stats_app_layer_flow_dcerpc_udp_not_found]
+      and [stats][app_layer][flow][dcerpc_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_dcerpc_udp_labels.key" => "stats_app_layer_flow_dcerpc_udp"
+            "stats_app_layer_flow_dcerpc_udp_labels.key" =>
+            "stats_app_layer_flow_dcerpc_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_dcerpc_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_dcerpc_udp_labels"
           }
         }
       }
@@ -33370,19 +38567,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_dns_udp_labels.value" => "%{stats.app_layer.flow.dns_udp}"
+          "stats_app_layer_flow_dns_udp_labels.value" =>
+          "%{stats.app_layer.flow.dns_udp}"
         }
         on_error => "stats_app_layer_flow_dns_udp_not_found"
       }
-      if ![stats_app_layer_flow_dns_udp_not_found] and [stats][app_layer][flow][dns_udp] != "" {
+      if ![stats_app_layer_flow_dns_udp_not_found]
+      and [stats][app_layer][flow][dns_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_dns_udp_labels.key" => "stats_app_layer_flow_dns_udp"
+            "stats_app_layer_flow_dns_udp_labels.key" =>
+            "stats_app_layer_flow_dns_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_dns_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_dns_udp_labels"
           }
         }
       }
@@ -33396,19 +38597,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_nfs_udp_labels.value" => "%{stats.app_layer.flow.nfs_udp}"
+          "stats_app_layer_flow_nfs_udp_labels.value" =>
+          "%{stats.app_layer.flow.nfs_udp}"
         }
         on_error => "stats_app_layer_flow_nfs_udp_not_found"
       }
-      if ![stats_app_layer_flow_nfs_udp_not_found] and [stats][app_layer][flow][nfs_udp] != "" {
+      if ![stats_app_layer_flow_nfs_udp_not_found]
+      and [stats][app_layer][flow][nfs_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_nfs_udp_labels.key" => "stats_app_layer_flow_nfs_udp"
+            "stats_app_layer_flow_nfs_udp_labels.key" =>
+            "stats_app_layer_flow_nfs_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_nfs_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_nfs_udp_labels"
           }
         }
       }
@@ -33422,19 +38627,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_krb5_udp_labels.value" => "%{stats.app_layer.flow.krb5_udp}"
+          "stats_app_layer_flow_krb5_udp_labels.value" =>
+          "%{stats.app_layer.flow.krb5_udp}"
         }
         on_error => "stats_app_layer_flow_krb5_udp_not_found"
       }
-      if ![stats_app_layer_flow_krb5_udp_not_found] and [stats][app_layer][flow][krb5_udp] != "" {
+      if ![stats_app_layer_flow_krb5_udp_not_found]
+      and [stats][app_layer][flow][krb5_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_krb5_udp_labels.key" => "stats_app_layer_flow_krb5_udp"
+            "stats_app_layer_flow_krb5_udp_labels.key" =>
+            "stats_app_layer_flow_krb5_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_krb5_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_krb5_udp_labels"
           }
         }
       }
@@ -33448,19 +38657,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_flow_failed_udp_labels.value" => "%{stats.app_layer.flow.failed_udp}"
+          "stats_app_layer_flow_failed_udp_labels.value" =>
+          "%{stats.app_layer.flow.failed_udp}"
         }
         on_error => "stats_app_layer_flow_failed_udp_not_found"
       }
-      if ![stats_app_layer_flow_failed_udp_not_found] and [stats][app_layer][flow][failed_udp] != "" {
+      if ![stats_app_layer_flow_failed_udp_not_found]
+      and [stats][app_layer][flow][failed_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_flow_failed_udp_labels.key" => "stats_app_layer_flow_failed_udp"
+            "stats_app_layer_flow_failed_udp_labels.key" =>
+            "stats_app_layer_flow_failed_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_flow_failed_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_flow_failed_udp_labels"
           }
         }
       }
@@ -33478,7 +38691,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_http_not_found"
       }
-      if ![stats_app_layer_tx_http_not_found] and [stats][app_layer][tx][http] != "" {
+      if ![stats_app_layer_tx_http_not_found]
+      and [stats][app_layer][tx][http] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_http_labels.key" => "stats_app_layer_tx_http"
@@ -33504,7 +38718,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_ftp_not_found"
       }
-      if ![stats_app_layer_tx_ftp_not_found] and [stats][app_layer][tx][ftp] != "" {
+      if ![stats_app_layer_tx_ftp_not_found]
+      and [stats][app_layer][tx][ftp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_ftp_labels.key" => "stats_app_layer_tx_ftp"
@@ -33530,7 +38745,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_smtp_not_found"
       }
-      if ![stats_app_layer_tx_smtp_not_found] and [stats][app_layer][tx][smtp] != "" {
+      if ![stats_app_layer_tx_smtp_not_found]
+      and [stats][app_layer][tx][smtp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_smtp_labels.key" => "stats_app_layer_tx_smtp"
@@ -33556,7 +38772,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_tls_not_found"
       }
-      if ![stats_app_layer_tx_tls_not_found] and [stats][app_layer][tx][tls] != "" {
+      if ![stats_app_layer_tx_tls_not_found]
+      and [stats][app_layer][tx][tls] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_tls_labels.key" => "stats_app_layer_tx_tls"
@@ -33582,7 +38799,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_ssh_not_found"
       }
-      if ![stats_app_layer_tx_ssh_not_found] and [stats][app_layer][tx][ssh] != "" {
+      if ![stats_app_layer_tx_ssh_not_found]
+      and [stats][app_layer][tx][ssh] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_ssh_labels.key" => "stats_app_layer_tx_ssh"
@@ -33608,7 +38826,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_imap_not_found"
       }
-      if ![stats_app_layer_tx_imap_not_found] and [stats][app_layer][tx][imap] != "" {
+      if ![stats_app_layer_tx_imap_not_found]
+      and [stats][app_layer][tx][imap] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_imap_labels.key" => "stats_app_layer_tx_imap"
@@ -33634,7 +38853,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_smb_not_found"
       }
-      if ![stats_app_layer_tx_smb_not_found] and [stats][app_layer][tx][smb] != "" {
+      if ![stats_app_layer_tx_smb_not_found]
+      and [stats][app_layer][tx][smb] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_smb_labels.key" => "stats_app_layer_tx_smb"
@@ -33656,19 +38876,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_dcerpc_tcp_labels.value" => "%{stats.app_layer.tx.dcerpc_tcp}"
+          "stats_app_layer_tx_dcerpc_tcp_labels.value" =>
+          "%{stats.app_layer.tx.dcerpc_tcp}"
         }
         on_error => "stats_app_layer_tx_dcerpc_tcp_not_found"
       }
-      if ![stats_app_layer_tx_dcerpc_tcp_not_found] and [stats][app_layer][tx][dcerpc_tcp] != "" {
+      if ![stats_app_layer_tx_dcerpc_tcp_not_found]
+      and [stats][app_layer][tx][dcerpc_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_dcerpc_tcp_labels.key" => "stats_app_layer_tx_dcerpc_tcp"
+            "stats_app_layer_tx_dcerpc_tcp_labels.key" =>
+            "stats_app_layer_tx_dcerpc_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_dcerpc_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_dcerpc_tcp_labels"
           }
         }
       }
@@ -33682,19 +38906,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_dns_tcp_labels.value" => "%{stats.app_layer.tx.dns_tcp}"
+          "stats_app_layer_tx_dns_tcp_labels.value" =>
+          "%{stats.app_layer.tx.dns_tcp}"
         }
         on_error => "stats_app_layer_tx_dns_tcp_not_found"
       }
-      if ![stats_app_layer_tx_dns_tcp_not_found] and [stats][app_layer][tx][dns_tcp] != "" {
+      if ![stats_app_layer_tx_dns_tcp_not_found]
+      and [stats][app_layer][tx][dns_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_dns_tcp_labels.key" => "stats_app_layer_tx_dns_tcp"
+            "stats_app_layer_tx_dns_tcp_labels.key" =>
+            "stats_app_layer_tx_dns_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_dns_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_dns_tcp_labels"
           }
         }
       }
@@ -33708,19 +38936,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_nfs_tcp_labels.value" => "%{stats.app_layer.tx.nfs_tcp}"
+          "stats_app_layer_tx_nfs_tcp_labels.value" =>
+          "%{stats.app_layer.tx.nfs_tcp}"
         }
         on_error => "stats_app_layer_tx_nfs_tcp_not_found"
       }
-      if ![stats_app_layer_tx_nfs_tcp_not_found] and [stats][app_layer][tx][nfs_tcp] != "" {
+      if ![stats_app_layer_tx_nfs_tcp_not_found]
+      and [stats][app_layer][tx][nfs_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_nfs_tcp_labels.key" => "stats_app_layer_tx_nfs_tcp"
+            "stats_app_layer_tx_nfs_tcp_labels.key" =>
+            "stats_app_layer_tx_nfs_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_nfs_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_nfs_tcp_labels"
           }
         }
       }
@@ -33738,7 +38970,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_ntp_not_found"
       }
-      if ![stats_app_layer_tx_ntp_not_found] and [stats][app_layer][tx][ntp] != "" {
+      if ![stats_app_layer_tx_ntp_not_found]
+      and [stats][app_layer][tx][ntp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_ntp_labels.key" => "stats_app_layer_tx_ntp"
@@ -33760,19 +38993,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_ftp-data_labels.value" => "%{stats.app_layer.tx.ftp-data}"
+          "stats_app_layer_tx_ftp-data_labels.value" =>
+          "%{stats.app_layer.tx.ftp-data}"
         }
         on_error => "stats_app_layer_tx_ftp-data_not_found"
       }
-      if ![stats_app_layer_tx_ftp-data_not_found] and [stats][app_layer][tx][ftp-data] != "" {
+      if ![stats_app_layer_tx_ftp-data_not_found]
+      and [stats][app_layer][tx][ftp-data] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_ftp-data_labels.key" => "stats_app_layer_tx_ftp-data"
+            "stats_app_layer_tx_ftp-data_labels.key" =>
+            "stats_app_layer_tx_ftp-data"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_ftp-data_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_ftp-data_labels"
           }
         }
       }
@@ -33790,7 +39027,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_tftp_not_found"
       }
-      if ![stats_app_layer_tx_tftp_not_found] and [stats][app_layer][tx][tftp] != "" {
+      if ![stats_app_layer_tx_tftp_not_found]
+      and [stats][app_layer][tx][tftp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_tftp_labels.key" => "stats_app_layer_tx_tftp"
@@ -33812,11 +39050,13 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_ikev2_labels.value" => "%{stats.app_layer.tx.ikev2}"
+          "stats_app_layer_tx_ikev2_labels.value" =>
+          "%{stats.app_layer.tx.ikev2}"
         }
         on_error => "stats_app_layer_tx_ikev2_not_found"
       }
-      if ![stats_app_layer_tx_ikev2_not_found] and [stats][app_layer][tx][ikev2] != "" {
+      if ![stats_app_layer_tx_ikev2_not_found]
+      and [stats][app_layer][tx][ikev2] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_ikev2_labels.key" => "stats_app_layer_tx_ikev2"
@@ -33838,19 +39078,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_krb5_tcp_labels.value" => "%{stats.app_layer.tx.krb5_tcp}"
+          "stats_app_layer_tx_krb5_tcp_labels.value" =>
+          "%{stats.app_layer.tx.krb5_tcp}"
         }
         on_error => "stats_app_layer_tx_krb5_tcp_not_found"
       }
-      if ![stats_app_layer_tx_krb5_tcp_not_found] and [stats][app_layer][tx][krb5_tcp] != "" {
+      if ![stats_app_layer_tx_krb5_tcp_not_found]
+      and [stats][app_layer][tx][krb5_tcp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_krb5_tcp_labels.key" => "stats_app_layer_tx_krb5_tcp"
+            "stats_app_layer_tx_krb5_tcp_labels.key" =>
+            "stats_app_layer_tx_krb5_tcp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_krb5_tcp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_krb5_tcp_labels"
           }
         }
       }
@@ -33868,7 +39112,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_dhcp_not_found"
       }
-      if ![stats_app_layer_tx_dhcp_not_found] and [stats][app_layer][tx][dhcp] != "" {
+      if ![stats_app_layer_tx_dhcp_not_found]
+      and [stats][app_layer][tx][dhcp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_dhcp_labels.key" => "stats_app_layer_tx_dhcp"
@@ -33894,7 +39139,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_rfb_not_found"
       }
-      if ![stats_app_layer_tx_rfb_not_found] and [stats][app_layer][tx][rfb] != "" {
+      if ![stats_app_layer_tx_rfb_not_found]
+      and [stats][app_layer][tx][rfb] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_rfb_labels.key" => "stats_app_layer_tx_rfb"
@@ -33920,7 +39166,8 @@ filter {
         }
         on_error => "stats_app_layer_tx_rdp_not_found"
       }
-      if ![stats_app_layer_tx_rdp_not_found] and [stats][app_layer][tx][rdp] != "" {
+      if ![stats_app_layer_tx_rdp_not_found]
+      and [stats][app_layer][tx][rdp] != "" {
         mutate {
           replace => {
             "stats_app_layer_tx_rdp_labels.key" => "stats_app_layer_tx_rdp"
@@ -33942,19 +39189,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_dcerpc_udp_labels.value" => "%{stats.app_layer.tx.dcerpc_udp}"
+          "stats_app_layer_tx_dcerpc_udp_labels.value" =>
+          "%{stats.app_layer.tx.dcerpc_udp}"
         }
         on_error => "stats_app_layer_tx_dcerpc_udp_not_found"
       }
-      if ![stats_app_layer_tx_dcerpc_udp_not_found] and [stats][app_layer][tx][dcerpc_udp] != "" {
+      if ![stats_app_layer_tx_dcerpc_udp_not_found]
+      and [stats][app_layer][tx][dcerpc_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_dcerpc_udp_labels.key" => "stats_app_layer_tx_dcerpc_udp"
+            "stats_app_layer_tx_dcerpc_udp_labels.key" =>
+            "stats_app_layer_tx_dcerpc_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_dcerpc_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_dcerpc_udp_labels"
           }
         }
       }
@@ -33968,14 +39219,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_dns_udp_labels.value" => "%{stats.app_layer.tx.dns_udp}"
+          "stats_app_layer_tx_dns_udp_labels.value" =>
+          "%{stats.app_layer.tx.dns_udp}"
         }
         on_error => "stats_app_layer_tx_dns_udp_not_found"
       }
-      if ![stats_app_layer_tx_dns_udp_not_found] and [stats][app_layer][tx][dns_udp] != "" {
+      if ![stats_app_layer_tx_dns_udp_not_found]
+      and [stats][app_layer][tx][dns_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_dns_udp_labels.key" => "stats_app_layer_tx_dns_udp"
+            "stats_app_layer_tx_dns_udp_labels.key" =>
+            "stats_app_layer_tx_dns_udp"
           }
         }
         mutate {
@@ -33994,14 +39248,17 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_nfs_udp_labels.value" => "%{stats.app_layer.tx.nfs_udp}"
+          "stats_app_layer_tx_nfs_udp_labels.value" =>
+          "%{stats.app_layer.tx.nfs_udp}"
         }
         on_error => "stats_app_layer_tx_nfs_udp_not_found"
       }
-      if ![stats_app_layer_tx_nfs_udp_not_found] and [stats][app_layer][tx][nfs_udp] != "" {
+      if ![stats_app_layer_tx_nfs_udp_not_found]
+      and [stats][app_layer][tx][nfs_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_nfs_udp_labels.key" => "stats_app_layer_tx_nfs_udp"
+            "stats_app_layer_tx_nfs_udp_labels.key" =>
+            "stats_app_layer_tx_nfs_udp"
           }
         }
         mutate {
@@ -34020,19 +39277,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_tx_krb5_udp_labels.value" => "%{stats.app_layer.tx.krb5_udp}"
+          "stats_app_layer_tx_krb5_udp_labels.value" =>
+          "%{stats.app_layer.tx.krb5_udp}"
         }
         on_error => "stats_app_layer_tx_krb5_udp_not_found"
       }
-      if ![stats_app_layer_tx_krb5_udp_not_found] and [stats][app_layer][tx][krb5_udp] != "" {
+      if ![stats_app_layer_tx_krb5_udp_not_found]
+      and [stats][app_layer][tx][krb5_udp] != "" {
         mutate {
           replace => {
-            "stats_app_layer_tx_krb5_udp_labels.key" => "stats_app_layer_tx_krb5_udp"
+            "stats_app_layer_tx_krb5_udp_labels.key" =>
+            "stats_app_layer_tx_krb5_udp"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_tx_krb5_udp_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_tx_krb5_udp_labels"
           }
         }
       }
@@ -34046,19 +39307,23 @@ filter {
 
       mutate {
         replace => {
-          "stats_app_layer_expectations_labels.value" => "%{stats.app_layer.expectations}"
+          "stats_app_layer_expectations_labels.value" =>
+          "%{stats.app_layer.expectations}"
         }
         on_error => "stats_app_layer_expectations_not_found"
       }
-      if ![stats_app_layer_expectations_not_found] and [stats][app_layer][expectations] != "" {
+      if ![stats_app_layer_expectations_not_found]
+      and [stats][app_layer][expectations] != "" {
         mutate {
           replace => {
-            "stats_app_layer_expectations_labels.key" => "stats_app_layer_expectations"
+            "stats_app_layer_expectations_labels.key" =>
+            "stats_app_layer_expectations"
           }
         }
         mutate {
           merge => {
-            "suricata_stats_about.labels" => "stats_app_layer_expectations_labels"
+            "suricata_stats_about.labels" =>
+            "stats_app_layer_expectations_labels"
           }
         }
       }
@@ -34174,13 +39439,13 @@ filter {
         on_error => "suricata_stats_about_not_found"
       }
     }
-
   }
 
   # ----------------------------------------------------------------------
-  # logschema
+  # Logschema
 
   else if [_path] == "logschema" {
+
     # UDM > About
     mutate {
       replace => {
@@ -34298,6 +39563,7 @@ filter {
           }
         }
     }
+
     mutate {
       merge => {
         "@output" => "event1"
@@ -34306,6 +39572,9 @@ filter {
     }
   }
   else {
+
+    @include["noun_host_asset_align.include"]
+
     mutate {
       merge => {
         "@output" => "event"


### PR DESCRIPTION
Adding support of new fields for existing logtypes which are currently supported in `corelight.conf`.